### PR TITLE
Issue #1 - Remove type for PublishFunction

### DIFF
--- a/dist/jaxs.d.ts
+++ b/dist/jaxs.d.ts
@@ -262,7 +262,7 @@ declare module 'app/index' {
   export class App {
     window: Window
     document: Document
-    publish: PublishFunction<any>
+    publish: PublishFunction
     subscribe: Subscribe
     bus: JaxsBus
     state: State
@@ -456,13 +456,13 @@ declare module 'types' {
     document: Document
     window: Window
   }
-  export type DefaultBusListenerOptions<T> = {
-    publish: PublishFunction<T>
+  export type DefaultBusListenerOptions = {
+    publish: PublishFunction
     eventName: string
   }
   export type ListenerKit = AppAdditionListenerOptions &
-    DefaultBusListenerOptions<any>
-  export type PublishFunction<T> = (event: string, payload: T) => void
+    DefaultBusListenerOptions
+  export type PublishFunction = (event: string, payload: any) => void
   export type BusListener<T> = (payload: T, listenerKit: ListenerKit) => void
   export type BusEventMatcher = string | RegExp
   export type ExactSubscriptionData<T> = {
@@ -694,7 +694,7 @@ declare module 'app/builder' {
   class AppBuilder {
     window: Window
     document: Document
-    publish: PublishFunction<any>
+    publish: PublishFunction
     subscribe: Subscribe
     bus: JaxsBus
     state: State

--- a/lib/app/builder.ts
+++ b/lib/app/builder.ts
@@ -10,7 +10,7 @@ import {
 class AppBuilder {
   window: Window
   document: Document
-  publish: PublishFunction<any>
+  publish: PublishFunction
   subscribe: Subscribe
   bus: JaxsBus
   state: State

--- a/lib/app/index.ts
+++ b/lib/app/index.ts
@@ -12,7 +12,7 @@ import { startNavigation } from '../navigation/start'
 export class App {
   window: Window
   document: Document
-  publish: PublishFunction<any>
+  publish: PublishFunction
   subscribe: Subscribe
   bus: JaxsBus
   state: State

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -192,15 +192,14 @@ export type AppAdditionListenerOptions = {
   document: Document
   window: Window
 }
-export type DefaultBusListenerOptions<T> = {
-  publish: PublishFunction<T>
+export type DefaultBusListenerOptions = {
+  publish: PublishFunction
   eventName: string
 }
-export type ListenerKit = AppAdditionListenerOptions &
-  DefaultBusListenerOptions<any>
+export type ListenerKit = AppAdditionListenerOptions & DefaultBusListenerOptions
 // this type name, but progressively.
 
-export type PublishFunction<T> = (event: string, payload: T) => void
+export type PublishFunction = (event: string, payload: any) => void
 export type BusListener<T> = (payload: T, listenerKit: ListenerKit) => void
 export type BusEventMatcher = string | RegExp
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jaxs",
   "description": "Modular J/TSX application framework",
   "private": false,
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "scripts": {
     "build": "vite build && npm run build:types",

--- a/test/support/render-kit.ts
+++ b/test/support/render-kit.ts
@@ -1,5 +1,5 @@
 import { vi, Mocked } from 'vitest'
-import { createTestDom, setupDom } from './test-dom'
+import { createTestDom } from './test-dom'
 import { createState } from '../../lib/state'
 import { createBus, type JaxsBus } from '../../lib/bus'
 import { PublishFunction, BusEventMatcher, BusListener } from '../../lib/types'
@@ -10,7 +10,7 @@ export const createRenderKit = <T>(messageBus = {} as Partial<JaxsBus>) => {
   const document = createTestDom()
 
   const busOptions = {
-    publish: messageBus.publish || (vi.fn() as Mocked<PublishFunction<T>>),
+    publish: messageBus.publish || (vi.fn() as Mocked<PublishFunction>),
     subscribe: messageBus.subscribe || (vi.fn() as Subscribe<T>),
   }
   const state = createState(busOptions.publish)


### PR DESCRIPTION
The publish function has a payload type it sets up, that would be great to correlate with an event name, but that's not how it's working. This removes the typing, which I was having to any and ignore everywhere.