### PR TITLE
Bug: Issue #28 - more cloning to avoid mutating initial state

### DIFF
--- a/dist/jaxs.d.ts
+++ b/dist/jaxs.d.ts
@@ -1,726 +1,1029 @@
-declare module "state/is" {
-    export const isBoolean: (value: any) => value is boolean;
-    export const isNumber: (value: any) => value is number;
-    export const isString: (value: any) => value is string;
-    export const isArray: (value: any) => value is any[];
-    export const isObject: (value: any) => boolean;
+declare module 'state/is' {
+  export const isBoolean: (value: any) => value is boolean
+  export const isNumber: (value: any) => value is number
+  export const isString: (value: any) => value is string
+  export const isArray: (value: any) => value is any[]
+  export const isObject: (value: any) => boolean
 }
-declare module "state/equality" {
-    type Object = Record<string, any>;
-    export const areElementsEqual: (oldValue: any, newValue: any) => boolean;
-    export const areObjectsEqual: (oldValue: Object, newValue: Object) => any;
-    export const areArraysEqual: (oldValue: any[], newValue: any[]) => any;
-    export const areEqual: (oldValue: any, newValue: any) => any;
+declare module 'state/equality' {
+  type Object = Record<string, any>
+  export const areElementsEqual: (oldValue: any, newValue: any) => boolean
+  export const areObjectsEqual: (oldValue: Object, newValue: Object) => any
+  export const areArraysEqual: (oldValue: any[], newValue: any[]) => any
+  export const areEqual: (oldValue: any, newValue: any) => any
 }
-declare module "state/store" {
-    import type { State, StoreInitializationOptions, StoreUpdaterOrValue, StoreUpdater } from "types";
-    export class Store<T> {
-        parent: State;
-        name: string;
-        updater: StoreUpdater<T>;
-        _value: T;
-        initialValue: T;
-        constructor(options: StoreInitializationOptions<T>);
-        get ['value'](): T;
-        set ['value'](value: T);
-        reset(): void;
-        update(updater: StoreUpdaterOrValue<T>): void;
-        private updateValue;
-        private getUpdatedValue;
-    }
+declare module 'state/store' {
+  import type {
+    State,
+    StoreInitializationOptions,
+    StoreUpdaterOrValue,
+    StoreUpdater,
+  } from 'types'
+  export class Store<T> {
+    parent: State
+    name: string
+    updater: StoreUpdater<T>
+    _value: T
+    initialValue: T
+    constructor(options: StoreInitializationOptions<T>)
+    get ['value'](): T
+    set ['value'](value: T)
+    reset(): void
+    update(updater: StoreUpdaterOrValue<T>): void
+    private updateValue
+    private getUpdatedValue
+  }
 }
-declare module "state/store-updater" {
-    import type { Store, StoreUpdaterOrValue } from "types";
-    export class StoreUpdaterBase<T> {
-        store: Store<T>;
-        constructor(store: Store<T>);
-        update(updater: StoreUpdaterOrValue<T>): void;
-        reset(): void;
-        get value(): T;
-    }
+declare module 'state/store-updater' {
+  import type { Store, StoreUpdaterOrValue } from 'types'
+  export class StoreUpdaterBase<T> {
+    store: Store<T>
+    constructor(store: Store<T>)
+    update(updater: StoreUpdaterOrValue<T>): void
+    reset(): void
+    get value(): T
+  }
 }
-declare module "state/updaters/object" {
-    import { Store } from "types";
-    import { StoreUpdaterBase } from "state/store-updater";
-    export class StoreUpdaterObject<T extends object> extends StoreUpdaterBase<T> {
-        updateAttribute(name: keyof T, value: T[keyof T]): void;
-        updateDynamicAttribute(name: string, value: any): void;
-        isKey(key: string): boolean;
-        isValueType(key: keyof T, value: any): boolean;
-        resetAttribute(name: keyof T): void;
-    }
-    export const objectUpdater: <T extends Object>(store: Store<T>) => StoreUpdaterObject<T>;
+declare module 'state/updaters/object' {
+  import { Store } from 'types'
+  import { StoreUpdaterBase } from 'state/store-updater'
+  export class StoreUpdaterObject<
+    T extends object,
+  > extends StoreUpdaterBase<T> {
+    updateAttribute(name: keyof T, value: T[keyof T]): void
+    updateDynamicAttribute(name: string, value: any): void
+    isKey(key: string): boolean
+    isValueType(key: keyof T, value: any): boolean
+    resetAttribute(name: keyof T): void
+  }
+  export const objectUpdater: <T extends Object>(
+    store: Store<T>,
+  ) => StoreUpdaterObject<T>
 }
-declare module "state/updaters/list" {
-    import { StoreListSorterFunction, Store } from "types";
-    import { StoreUpdaterBase } from "state/store-updater";
-    export class StoreUpdaterList<T> extends StoreUpdaterBase<T[]> {
-        push(element: T): void;
-        pop(): T;
-        unshift(element: T): void;
-        shift(): T;
-        addSorter(name: string, sorter: StoreListSorterFunction<T>): void;
-        sortBy(sorter: StoreListSorterFunction<T>): void;
-        insertAt(index: number, item: T): void;
-        remove(value: T): void;
-        removeBy(matcherFunction: (value: T) => boolean): void;
-    }
-    export const listUpdater: <T>(store: Store<T[]>) => StoreUpdaterList<T>;
+declare module 'state/updaters/list' {
+  import { StoreListSorterFunction, Store } from 'types'
+  import { StoreUpdaterBase } from 'state/store-updater'
+  export class StoreUpdaterList<T> extends StoreUpdaterBase<T[]> {
+    push(element: T): void
+    pop(): T
+    unshift(element: T): void
+    shift(): T
+    addSorter(name: string, sorter: StoreListSorterFunction<T>): void
+    sortBy(sorter: StoreListSorterFunction<T>): void
+    insertAt(index: number, item: T): void
+    remove(value: T): void
+    removeBy(matcherFunction: (value: T) => boolean): void
+  }
+  export const listUpdater: <T>(store: Store<T[]>) => StoreUpdaterList<T>
 }
-declare module "state/updaters/boolean" {
-    import { Store } from "types";
-    import { StoreUpdaterBase } from "state/store-updater";
-    export class StoreUpdaterBoolean extends StoreUpdaterBase<boolean> {
-        toggle(): void;
-        setTrue(): void;
-        setFalse(): void;
-    }
-    export const booleanUpdater: (store: Store<boolean>) => StoreUpdaterBoolean;
+declare module 'state/updaters/boolean' {
+  import { Store } from 'types'
+  import { StoreUpdaterBase } from 'state/store-updater'
+  export class StoreUpdaterBoolean extends StoreUpdaterBase<boolean> {
+    toggle(): void
+    setTrue(): void
+    setFalse(): void
+  }
+  export const booleanUpdater: (store: Store<boolean>) => StoreUpdaterBoolean
 }
-declare module "state/updaters" {
-    export const updaters: {
-        object: <T extends Object>(store: import("state").Store<T>) => import("state/updaters/object").StoreUpdaterObject<T>;
-        list: <T>(store: import("state").Store<T[]>) => import("state/updaters/list").StoreUpdaterList<T>;
-        boolean: (store: import("state").Store<boolean>) => import("state/updaters/boolean").StoreUpdaterBoolean;
-    };
+declare module 'state/updaters' {
+  export const updaters: {
+    object: <T extends Object>(
+      store: import('state').Store<T>,
+    ) => import('state/updaters/object').StoreUpdaterObject<T>
+    list: <T>(
+      store: import('state').Store<T[]>,
+    ) => import('state/updaters/list').StoreUpdaterList<T>
+    boolean: (
+      store: import('state').Store<boolean>,
+    ) => import('state/updaters/boolean').StoreUpdaterBoolean
+  }
 }
-declare module "state/index" {
-    import { Store } from "state/store";
-    import type { StatePublisher, StateTransactionUpdater, StoresCollection } from "types";
-    import { updaters } from "state/updaters";
-    export const eventName = "state";
-    export class State {
-        publisher: StatePublisher;
-        stores: StoresCollection;
-        eventNamePrefix: string;
-        notifications: Set<string>;
-        inTransaction: boolean;
-        constructor(publisher: StatePublisher);
-        create<T>(name: string, initialState: T): Store<T>;
-        store<T>(name: string): Store<T>;
-        get<T>(name: string): T;
-        getAll(names: string[]): {};
-        notify(name: string): void;
-        update(name: string, newValue: any): void;
-        transaction(updater: StateTransactionUpdater): void;
-        publishAll(): void;
-        publish(name: string): void;
-        event(name: string): string;
-    }
-    export const createState: (publisher: StatePublisher) => State;
-    export { Store, updaters };
+declare module 'state/index' {
+  import { Store } from 'state/store'
+  import type {
+    StatePublisher,
+    StateTransactionUpdater,
+    StoresCollection,
+  } from 'types'
+  import { updaters } from 'state/updaters'
+  export const eventName = 'state'
+  export class State {
+    publisher: StatePublisher
+    stores: StoresCollection
+    eventNamePrefix: string
+    notifications: Set<string>
+    inTransaction: boolean
+    constructor(publisher: StatePublisher)
+    create<T>(name: string, initialState: T): Store<T>
+    store<T>(name: string): Store<T>
+    get<T>(name: string): T
+    getAll(names: string[]): {}
+    notify(name: string): void
+    update(name: string, newValue: any): void
+    transaction(updater: StateTransactionUpdater): void
+    publishAll(): void
+    publish(name: string): void
+    event(name: string): string
+  }
+  export const createState: (publisher: StatePublisher) => State
+  export { Store, updaters }
 }
-declare module "bus/exact-subscriptions" {
-    import { ExactSubscriptionData, BusListener, Unsubscribe } from "types";
-    export class ExactSubscriptions {
-        lookup: Record<string, ExactSubscriptionData<any>[]>;
-        constructor();
-        add<T>(matcher: string, listener: BusListener<T>, index: number): Unsubscribe;
-        remove<T>(subscription: ExactSubscriptionData<T>): void;
-        matches(event: string): ExactSubscriptionData<any>[];
-        ensureArrayFor(matcher: string): void;
-    }
+declare module 'bus/exact-subscriptions' {
+  import { ExactSubscriptionData, BusListener, Unsubscribe } from 'types'
+  export class ExactSubscriptions {
+    lookup: Record<string, ExactSubscriptionData<any>[]>
+    constructor()
+    add<T>(
+      matcher: string,
+      listener: BusListener<T>,
+      index: number,
+    ): Unsubscribe
+    remove<T>(subscription: ExactSubscriptionData<T>): void
+    matches(event: string): ExactSubscriptionData<any>[]
+    ensureArrayFor(matcher: string): void
+  }
 }
-declare module "bus/fuzzy-subscriptions" {
-    import { FuzzySubscriptionData, BusListener, Unsubscribe } from "types";
-    export class FuzzySubscriptions {
-        lookup: FuzzySubscriptionData<any>[];
-        constructor();
-        add<T>(matcher: RegExp, listener: BusListener<T>, index: number): Unsubscribe;
-        remove<T>(subscription: FuzzySubscriptionData<T>): void;
-        matches(event: string): FuzzySubscriptionData<any>[];
-    }
+declare module 'bus/fuzzy-subscriptions' {
+  import { FuzzySubscriptionData, BusListener, Unsubscribe } from 'types'
+  export class FuzzySubscriptions {
+    lookup: FuzzySubscriptionData<any>[]
+    constructor()
+    add<T>(
+      matcher: RegExp,
+      listener: BusListener<T>,
+      index: number,
+    ): Unsubscribe
+    remove<T>(subscription: FuzzySubscriptionData<T>): void
+    matches(event: string): FuzzySubscriptionData<any>[]
+  }
 }
-declare module "bus/custom-periodic-publisher" {
-    import { PeriodicPublisher, PublishFunction, PeriodicTimerFunction, CustomPeriodicPublisherOptions } from "types";
-    export class CustomPeriodicPublisher implements PeriodicPublisher {
-        publish: PublishFunction;
-        event: string;
-        payload: any;
-        stopped: boolean;
-        timer: PeriodicTimerFunction;
-        timeoutId: any;
-        stop: () => void;
-        callCount: number;
-        startedAt: number;
-        constructor({ publish, event, payload, timer, }: CustomPeriodicPublisherOptions);
-        start(): void;
-        setNewTimeout: () => void;
-        calculateNextTime: () => number;
-        diff(): number;
-        stopTimeout(): void;
-        publishEvent(): void;
-    }
+declare module 'bus/custom-periodic-publisher' {
+  import {
+    PeriodicPublisher,
+    PublishFunction,
+    PeriodicTimerFunction,
+    CustomPeriodicPublisherOptions,
+  } from 'types'
+  export class CustomPeriodicPublisher implements PeriodicPublisher {
+    publish: PublishFunction
+    event: string
+    payload: any
+    stopped: boolean
+    timer: PeriodicTimerFunction
+    timeoutId: any
+    stop: () => void
+    callCount: number
+    startedAt: number
+    constructor({
+      publish,
+      event,
+      payload,
+      timer,
+    }: CustomPeriodicPublisherOptions)
+    start(): void
+    setNewTimeout: () => void
+    calculateNextTime: () => number
+    diff(): number
+    stopTimeout(): void
+    publishEvent(): void
+  }
 }
-declare module "bus/publish-periodically" {
-    import type { PublishPeriodicallyOptions } from "types";
-    export const publishPeriodically: (options: PublishPeriodicallyOptions) => () => void;
+declare module 'bus/publish-periodically' {
+  import type { PublishPeriodicallyOptions } from 'types'
+  export const publishPeriodically: (
+    options: PublishPeriodicallyOptions,
+  ) => () => void
 }
-declare module "bus/index" {
-    import { BusEventMatcher, BusListener, Unsubscribe, AppAdditionListenerOptions, ListenerKit } from "types";
-    import { ExactSubscriptions } from "bus/exact-subscriptions";
-    import { FuzzySubscriptions } from "bus/fuzzy-subscriptions";
-    import { publishPeriodically } from "bus/publish-periodically";
-    class JaxsBus {
-        options?: AppAdditionListenerOptions;
-        exactSubscriptions: ExactSubscriptions;
-        fuzzySubscriptions: FuzzySubscriptions;
-        currentIndex: number;
-        constructor();
-        subscribe<T>(matcher: BusEventMatcher, listener: BusListener<T>): Unsubscribe;
-        publish<T>(event: string, payload: T): void;
-        addListenerOptions(options: AppAdditionListenerOptions): void;
-        listenerOptions(event: string): ListenerKit;
-    }
-    const createBus: () => {
-        bus: JaxsBus;
-        publish: (event: string, payload: any) => void;
-        subscribe: (matcher: BusEventMatcher, listener: BusListener<any>) => Unsubscribe;
-    };
-    export { createBus, JaxsBus, ExactSubscriptions, FuzzySubscriptions, publishPeriodically, };
+declare module 'bus/index' {
+  import {
+    BusEventMatcher,
+    BusListener,
+    Unsubscribe,
+    AppAdditionListenerOptions,
+    ListenerKit,
+  } from 'types'
+  import { ExactSubscriptions } from 'bus/exact-subscriptions'
+  import { FuzzySubscriptions } from 'bus/fuzzy-subscriptions'
+  import { publishPeriodically } from 'bus/publish-periodically'
+  class JaxsBus {
+    options?: AppAdditionListenerOptions
+    exactSubscriptions: ExactSubscriptions
+    fuzzySubscriptions: FuzzySubscriptions
+    currentIndex: number
+    constructor()
+    subscribe<T>(
+      matcher: BusEventMatcher,
+      listener: BusListener<T>,
+    ): Unsubscribe
+    publish<T>(event: string, payload: T): void
+    addListenerOptions(options: AppAdditionListenerOptions): void
+    listenerOptions(event: string): ListenerKit
+  }
+  const createBus: () => {
+    bus: JaxsBus
+    publish: (event: string, payload: any) => void
+    subscribe: (
+      matcher: BusEventMatcher,
+      listener: BusListener<any>,
+    ) => Unsubscribe
+  }
+  export {
+    createBus,
+    JaxsBus,
+    ExactSubscriptions,
+    FuzzySubscriptions,
+    publishPeriodically,
+  }
 }
-declare module "rendering/templates/root" {
-    import type { JaxsElement, JaxsNodes, RenderKit, Renderable, JaxsNode } from "types";
-    export class Root {
-        template: Renderable;
-        selector: string;
-        renderKit: RenderKit;
-        dom: JaxsNodes;
-        parentElement?: JaxsElement | null;
-        constructor(template: Renderable, selector: string, renderKit: RenderKit);
-        renderAndAttach(renderKit: RenderKit): void;
-        render(renderKit: RenderKit): JaxsNode[];
-        attach(): void;
-        getParentElement(): Element;
-    }
-    export const render: (template: Renderable, selector: string, renderKit: RenderKit) => Root;
+declare module 'rendering/templates/root' {
+  import type {
+    JaxsElement,
+    JaxsNodes,
+    RenderKit,
+    Renderable,
+    JaxsNode,
+  } from 'types'
+  export class Root {
+    template: Renderable
+    selector: string
+    renderKit: RenderKit
+    dom: JaxsNodes
+    parentElement?: JaxsElement | null
+    constructor(template: Renderable, selector: string, renderKit: RenderKit)
+    renderAndAttach(renderKit: RenderKit): void
+    render(renderKit: RenderKit): JaxsNode[]
+    attach(): void
+    getParentElement(): Element
+  }
+  export const render: (
+    template: Renderable,
+    selector: string,
+    renderKit: RenderKit,
+  ) => Root
 }
-declare module "navigation/events" {
-    export const linkNavigationEvent = "go-to-href";
-    export const navigationEvent = "go-to";
-    export const locationChangeEvent = "navigation:location-change";
-    export const routeChangeEvent = "navigation:route-change";
+declare module 'navigation/events' {
+  export const linkNavigationEvent = 'go-to-href'
+  export const navigationEvent = 'go-to'
+  export const locationChangeEvent = 'navigation:location-change'
+  export const routeChangeEvent = 'navigation:route-change'
 }
-declare module "navigation/route-state" {
-    import { State } from "state/index";
-    export const createRouteState: (state: State) => void;
+declare module 'navigation/route-state' {
+  import { State } from 'state/index'
+  export const createRouteState: (state: State) => void
 }
-declare module "navigation/find-href" {
-    export const findHref: (node: HTMLElement) => string;
+declare module 'navigation/find-href' {
+  export const findHref: (node: HTMLElement) => string
 }
-declare module "navigation/navigate" {
-    import { ListenerKit } from "types";
-    export const navigate: (path: string, { publish, window }: ListenerKit) => void;
+declare module 'navigation/navigate' {
+  import { ListenerKit } from 'types'
+  export const navigate: (
+    path: string,
+    { publish, window }: ListenerKit,
+  ) => void
 }
-declare module "navigation/on-link-click" {
-    import { ListenerKit } from "types";
-    export const onLinkClick: (domEvent: MouseEvent, options: ListenerKit) => void;
+declare module 'navigation/on-link-click' {
+  import { ListenerKit } from 'types'
+  export const onLinkClick: (domEvent: MouseEvent, options: ListenerKit) => void
 }
-declare module "navigation/extract-query-params" {
-    export const extractQueryParams: (queryString: string) => {};
+declare module 'navigation/extract-query-params' {
+  export const extractQueryParams: (queryString: string) => {}
 }
-declare module "navigation/on-location-change" {
-    import { ListenerKit } from "types";
-    export const onLocationChange: (_: null, listenerOptions: ListenerKit) => void;
+declare module 'navigation/on-location-change' {
+  import { ListenerKit } from 'types'
+  export const onLocationChange: (_: null, listenerOptions: ListenerKit) => void
 }
-declare module "navigation/start" {
-    import type { App } from "app/index";
-    export const subscribeToNavigation: (app: App) => void;
-    export const subscribeToHistoryChange: (app: App) => void;
-    export const publishLocation: (app: App) => void;
-    export const startNavigation: (app: App) => void;
+declare module 'navigation/start' {
+  import type { App } from 'app/index'
+  export const subscribeToNavigation: (app: App) => void
+  export const subscribeToHistoryChange: (app: App) => void
+  export const publishLocation: (app: App) => void
+  export const startNavigation: (app: App) => void
 }
-declare module "app/index" {
-    import type { Renderable, RenderKit, Subscribe, PublishFunction } from "types";
-    import type { State } from "state/index";
-    import type { JaxsBus } from "bus/index";
-    import { Root } from "rendering/templates/root";
-    export class App {
-        window: Window;
-        document: Document;
-        publish: PublishFunction;
-        subscribe: Subscribe;
-        bus: JaxsBus;
-        state: State;
-        renderKit: RenderKit;
-        roots: Root[];
-        constructor({ window, document, publish, subscribe, bus, state, renderKit }: {
-            window: any;
-            document: any;
-            publish: any;
-            subscribe: any;
-            bus: any;
-            state: any;
-            renderKit: any;
-        });
-        render(template: Renderable, selector: string): Root;
-        startNavigation(): void;
-    }
+declare module 'app/index' {
+  import type { Renderable, RenderKit, Subscribe, PublishFunction } from 'types'
+  import type { State } from 'state/index'
+  import type { JaxsBus } from 'bus/index'
+  import { Root } from 'rendering/templates/root'
+  export class App {
+    window: Window
+    document: Document
+    publish: PublishFunction
+    subscribe: Subscribe
+    bus: JaxsBus
+    state: State
+    renderKit: RenderKit
+    roots: Root[]
+    constructor({
+      window,
+      document,
+      publish,
+      subscribe,
+      bus,
+      state,
+      renderKit,
+    }: {
+      window: any
+      document: any
+      publish: any
+      subscribe: any
+      bus: any
+      state: any
+      renderKit: any
+    })
+    render(template: Renderable, selector: string): Root
+    startNavigation(): void
+  }
 }
-declare module "types" {
-    import type { State } from "state/index";
-    import type { Store } from "state/store";
-    import type { StoreUpdaterBase } from "state/store-updater";
-    import type { StoreUpdaterBoolean } from "state/updaters/boolean";
-    import type { StoreUpdaterList } from "state/updaters/list";
-    import type { StoreUpdaterObject } from "state/updaters/object";
-    export type { App } from "app/index";
-    export { State, Store, StoreUpdaterBase, StoreUpdaterBoolean, StoreUpdaterList, StoreUpdaterObject, };
-    export type StoreUpdater<T> = StoreUpdaterBase<T> | StoreUpdaterObject<T extends object ? T : never> | StoreUpdaterBoolean | StoreUpdaterList<T>;
-    export type TextValue = string | number;
-    export interface JsxIded {
-        __jsx?: string;
-    }
-    export type JsxChangeId = {
-        element: JaxsNode;
-        index: number;
-    };
-    export type EventMap = {
-        domEvent: string;
-        busEvent: string;
-        listener: EventListener;
-    };
-    export type EventMaps = Record<string, EventMap>;
-    interface JsxEventMapped {
-        eventMaps: EventMaps;
-    }
-    export type JaxsElement = Element & JsxIded & JsxEventMapped;
-    export type JaxsText = Text & JsxIded;
-    export type JaxsSvgElement = SVGElement & JsxIded;
-    export type JaxsNode = JaxsElement | JaxsText | JaxsSvgElement;
-    export type JaxsNodes = JaxsNode[] | NodeListOf<JaxsNode>;
-    export type JaxsInput = HTMLInputElement & JsxIded & JsxEventMapped;
-    type NullValues = null | undefined;
-    export type ReactSourceObject = {
-        fileName: string;
-        lineNumber: string;
-        columnNumber: string;
-    };
-    interface SourceMap {
-        __source?: ReactSourceObject;
-    }
-    export type Props<T> = Partial<{
-        __source: ReactSourceObject;
-        children: JsxCollection;
-    }> & T;
-    export type PropValue = TextValue | NullValues | boolean | ReactSourceObject | JsxCollection;
-    export type TagAttributes = SourceMap & Record<string, string>;
-    export type TagEventAttributes = Record<string, string>;
-    export type TagAttributesAndEvents = {
-        attributes: TagAttributes;
-        events: TagEventAttributes;
-    };
-    export type DomPublish = (eventName: string, domEvent: Event) => void;
-    export type Subscribe = (matcher: BusEventMatcher, listener: BusListener<any>) => void;
-    export type RenderKit = {
-        document: Document;
-        window: Window;
-        publish: DomPublish;
-        subscribe: Subscribe;
-        state: State;
-        parent?: JaxsNode | null;
-    };
-    export interface Renderable {
-        render: (renderKit: RenderKit, parentElement?: JaxsElement) => JaxsNode[];
-    }
-    export type StaticTemplate = () => Renderable;
-    export type TypedTemplate<T> = (props: Props<T>) => Renderable;
-    export type Template<T> = StaticTemplate | TypedTemplate<T>;
-    export type JsxCollection = (Renderable | TextValue)[];
-    export enum ChangeInstructionTypes {
-        removeNode = 0,
-        insertNode = 1,// can be to move an existing element in the dom, or to add one
-        replaceNode = 2,
-        removeAttribute = 3,
-        addAttribute = 4,
-        updateAttribute = 5,
-        removeEvent = 6,
-        addEvent = 7,
-        updateEvent = 8,
-        changeValue = 9,
-        changeText = 10
-    }
-    export type RemoveInstructionData = {
-        name: string;
-        isSvg?: boolean;
-    };
-    export type AttributeInstructionData = {
-        name: string;
-        value: string;
-        isSvg?: boolean;
-    };
-    export type EventInstructionData = {
-        name: string;
-        value: EventListener;
-    };
-    export type UpdateEventInstructionData = {
-        name: string;
-        sourceValue: EventListener;
-        targetValue: EventListener;
-    };
-    export type InsertNodeData = {
-        parent: JaxsElement;
-        index: number;
-    };
-    type NullInstructionData = Record<string, never>;
-    export type InstructionData = RemoveInstructionData | AttributeInstructionData | EventInstructionData | UpdateEventInstructionData | InsertNodeData | NullInstructionData;
-    export type ChangeInstruction = {
-        source: JaxsNode;
-        target: JaxsNode;
-        type: ChangeInstructionTypes;
-        data: InstructionData;
-    };
-    export type ChangeInstructions = Array<ChangeInstruction>;
-    export type InstructionsUpdater = (instruction: ChangeInstruction) => void;
-    export type StoreMap = {
-        [key: string]: any;
-    };
-    export type ViewModel<ATTRIBUTES, STORE_MAP> = (storeMap: STORE_MAP) => Partial<ATTRIBUTES>;
-    export type BindSubscriptionList = string[];
-    export type BindParams<T, U> = {
-        Template: Template<T>;
-        viewModel?: ViewModel<T, U>;
-        subscriptions?: BindSubscriptionList;
-    };
-    export type AppAdditionListenerOptions = {
-        state: State;
-        document: Document;
-        window: Window;
-    };
-    export type DefaultBusListenerOptions = {
-        publish: PublishFunction;
-        eventName: string;
-    };
-    export type ListenerKit = AppAdditionListenerOptions & DefaultBusListenerOptions;
-    export type PublishFunction = (event: string, payload: any) => void;
-    export type BusListener<T> = (payload: T, listenerKit: ListenerKit) => void;
-    export type BusEventMatcher = string | RegExp;
-    export type ExactSubscriptionData<T> = {
-        listener: BusListener<T>;
-        index: number;
-        matcher: string;
-    };
-    export type FuzzySubscriptionData<T> = {
-        listener: BusListener<T>;
-        index: number;
-        matcher: RegExp;
-    };
-    export type Unsubscribe = () => void;
-    export type CreateAppBuilderArguments = {
-        window?: Window;
-        document?: Document;
-    };
-    export type RouteState = {
-        host: string;
-        path: string;
-        query: Record<string, string>;
-    };
-    export type AttributesWithChildren<T> = Props<T> & {
-        children?: JsxCollection;
-    };
-    export type DiffPair = {
-        source: JaxsNode;
-        target: JaxsNode;
-    };
-    export type CompileChildren = (sourceList: JaxsNodes, targetList: JaxsNodes, parent: JaxsElement) => ChangeInstructions;
-    export type StatePublisher = (event: string, payload: any) => void;
-    export type StateTransactionUpdater = (collection: StoresCollection) => void;
-    export type StoresCollection = Record<string, Store<any>>;
-    export type StoreInitializationOptions<T> = {
-        name: string;
-        parent: State;
-        value: T;
-    };
-    export type StoreDataUpdater<T> = (originalValue: T) => T;
-    export type UpdaterValue<T> = boolean | T | T[];
-    export type StoreUpdaterOrValue<T> = UpdaterValue<T> | StoreDataUpdater<T>;
-    export type StoreListSorterFunction<T> = (left: T, right: T) => number;
-    export type RouteMatcher = (routeState: RouteState) => boolean;
-    export type RenderedRoute = {
-        Partial: StaticTemplate;
-        match: RouteMatcher;
-    };
-    export interface PeriodicPublisher {
-        event: string;
-        publish: PublishFunction;
-        payload?: any;
-        start: () => void;
-        stop: () => void;
-    }
-    export type RequiredPeriodicPublisherOptions = {
-        event: string;
-        publish: PublishFunction;
-        payload?: any;
-    };
-    export type GeneralPeriodicOptions = {
-        period: number;
-        offset?: number;
-    };
-    export type CustomPeriodicOptions = {
-        timer: PeriodicTimerFunction;
-    };
-    export type GeneralPeriodicPublisherOptions = RequiredPeriodicPublisherOptions & GeneralPeriodicOptions;
-    export type CustomPeriodicPublisherOptions = RequiredPeriodicPublisherOptions & CustomPeriodicOptions;
-    export type PublishPeriodicallyOptions = GeneralPeriodicPublisherOptions | CustomPeriodicPublisherOptions;
-    export type PeriodicTimerFunctionOptions = {
-        timeDiff: number;
-        callCount: number;
-        stop: () => void;
-    };
-    export type PeriodicTimerFunction = (options: PeriodicTimerFunctionOptions) => number;
+declare module 'types' {
+  import type { State } from 'state/index'
+  import type { Store } from 'state/store'
+  import type { StoreUpdaterBase } from 'state/store-updater'
+  import type { StoreUpdaterBoolean } from 'state/updaters/boolean'
+  import type { StoreUpdaterList } from 'state/updaters/list'
+  import type { StoreUpdaterObject } from 'state/updaters/object'
+  export type { App } from 'app/index'
+  export {
+    State,
+    Store,
+    StoreUpdaterBase,
+    StoreUpdaterBoolean,
+    StoreUpdaterList,
+    StoreUpdaterObject,
+  }
+  export type StoreUpdater<T> =
+    | StoreUpdaterBase<T>
+    | StoreUpdaterObject<T extends object ? T : never>
+    | StoreUpdaterBoolean
+    | StoreUpdaterList<T>
+  export type TextValue = string | number
+  export interface JsxIded {
+    __jsx?: string
+  }
+  export type JsxChangeId = {
+    element: JaxsNode
+    index: number
+  }
+  export type EventMap = {
+    domEvent: string
+    busEvent: string
+    listener: EventListener
+  }
+  export type EventMaps = Record<string, EventMap>
+  interface JsxEventMapped {
+    eventMaps: EventMaps
+  }
+  export type JaxsElement = Element & JsxIded & JsxEventMapped
+  export type JaxsText = Text & JsxIded
+  export type JaxsSvgElement = SVGElement & JsxIded
+  export type JaxsNode = JaxsElement | JaxsText | JaxsSvgElement
+  export type JaxsNodes = JaxsNode[] | NodeListOf<JaxsNode>
+  export type JaxsInput = HTMLInputElement & JsxIded & JsxEventMapped
+  type NullValues = null | undefined
+  export type ReactSourceObject = {
+    fileName: string
+    lineNumber: string
+    columnNumber: string
+  }
+  interface SourceMap {
+    __source?: ReactSourceObject
+  }
+  export type Props<T> = Partial<{
+    __source: ReactSourceObject
+    children: JsxCollection
+  }> &
+    T
+  export type PropValue =
+    | TextValue
+    | NullValues
+    | boolean
+    | ReactSourceObject
+    | JsxCollection
+  export type TagAttributes = SourceMap & Record<string, string>
+  export type TagEventAttributes = Record<string, string>
+  export type TagAttributesAndEvents = {
+    attributes: TagAttributes
+    events: TagEventAttributes
+  }
+  export type DomPublish = (eventName: string, domEvent: Event) => void
+  export type Subscribe = (
+    matcher: BusEventMatcher,
+    listener: BusListener<any>,
+  ) => void
+  export type RenderKit = {
+    document: Document
+    window: Window
+    publish: DomPublish
+    subscribe: Subscribe
+    state: State
+    parent?: JaxsNode | null
+  }
+  export interface Renderable {
+    render: (renderKit: RenderKit, parentElement?: JaxsElement) => JaxsNode[]
+  }
+  export type StaticTemplate = () => Renderable
+  export type TypedTemplate<T> = (props: Props<T>) => Renderable
+  export type Template<T> = StaticTemplate | TypedTemplate<T>
+  export type JsxCollection = (Renderable | TextValue)[]
+  export enum ChangeInstructionTypes {
+    removeNode = 0,
+    insertNode = 1, // can be to move an existing element in the dom, or to add one
+    replaceNode = 2,
+    removeAttribute = 3,
+    addAttribute = 4,
+    updateAttribute = 5,
+    removeEvent = 6,
+    addEvent = 7,
+    updateEvent = 8,
+    changeValue = 9,
+    changeText = 10,
+  }
+  export type RemoveInstructionData = {
+    name: string
+    isSvg?: boolean
+  }
+  export type AttributeInstructionData = {
+    name: string
+    value: string
+    isSvg?: boolean
+  }
+  export type EventInstructionData = {
+    name: string
+    value: EventListener
+  }
+  export type UpdateEventInstructionData = {
+    name: string
+    sourceValue: EventListener
+    targetValue: EventListener
+  }
+  export type InsertNodeData = {
+    parent: JaxsElement
+    index: number
+  }
+  type NullInstructionData = Record<string, never>
+  export type InstructionData =
+    | RemoveInstructionData
+    | AttributeInstructionData
+    | EventInstructionData
+    | UpdateEventInstructionData
+    | InsertNodeData
+    | NullInstructionData
+  export type ChangeInstruction = {
+    source: JaxsNode
+    target: JaxsNode
+    type: ChangeInstructionTypes
+    data: InstructionData
+  }
+  export type ChangeInstructions = Array<ChangeInstruction>
+  export type InstructionsUpdater = (instruction: ChangeInstruction) => void
+  export type StoreMap = {
+    [key: string]: any
+  }
+  export type ViewModel<ATTRIBUTES, STORE_MAP> = (
+    storeMap: STORE_MAP,
+  ) => Partial<ATTRIBUTES>
+  export type BindSubscriptionList = string[]
+  export type BindParams<T, U> = {
+    Template: Template<T>
+    viewModel?: ViewModel<T, U>
+    subscriptions?: BindSubscriptionList
+  }
+  export type AppAdditionListenerOptions = {
+    state: State
+    document: Document
+    window: Window
+  }
+  export type DefaultBusListenerOptions = {
+    publish: PublishFunction
+    eventName: string
+  }
+  export type ListenerKit = AppAdditionListenerOptions &
+    DefaultBusListenerOptions
+  export type PublishFunction = (event: string, payload: any) => void
+  export type BusListener<T> = (payload: T, listenerKit: ListenerKit) => void
+  export type BusEventMatcher = string | RegExp
+  export type ExactSubscriptionData<T> = {
+    listener: BusListener<T>
+    index: number
+    matcher: string
+  }
+  export type FuzzySubscriptionData<T> = {
+    listener: BusListener<T>
+    index: number
+    matcher: RegExp
+  }
+  export type Unsubscribe = () => void
+  export type CreateAppBuilderArguments = {
+    window?: Window
+    document?: Document
+  }
+  export type RouteState = {
+    host: string
+    path: string
+    query: Record<string, string>
+  }
+  export type AttributesWithChildren<T> = Props<T> & {
+    children?: JsxCollection
+  }
+  export type DiffPair = {
+    source: JaxsNode
+    target: JaxsNode
+  }
+  export type CompileChildren = (
+    sourceList: JaxsNodes,
+    targetList: JaxsNodes,
+    parent: JaxsElement,
+  ) => ChangeInstructions
+  export type StatePublisher = (event: string, payload: any) => void
+  export type StateTransactionUpdater = (collection: StoresCollection) => void
+  export type StoresCollection = Record<string, Store<any>>
+  export type StoreInitializationOptions<T> = {
+    name: string
+    parent: State
+    value: T
+  }
+  export type StoreDataUpdater<T> = (originalValue: T) => T
+  export type UpdaterValue<T> = boolean | T | T[]
+  export type StoreUpdaterOrValue<T> = UpdaterValue<T> | StoreDataUpdater<T>
+  export type StoreListSorterFunction<T> = (left: T, right: T) => number
+  export type RouteMatcher = (routeState: RouteState) => boolean
+  export type RenderedRoute = {
+    Partial: StaticTemplate
+    match: RouteMatcher
+  }
+  export interface PeriodicPublisher {
+    event: string
+    publish: PublishFunction
+    payload?: any
+    start: () => void
+    stop: () => void
+  }
+  export type RequiredPeriodicPublisherOptions = {
+    event: string
+    publish: PublishFunction
+    payload?: any
+  }
+  export type GeneralPeriodicOptions = {
+    period: number
+    offset?: number
+  }
+  export type CustomPeriodicOptions = {
+    timer: PeriodicTimerFunction
+  }
+  export type GeneralPeriodicPublisherOptions =
+    RequiredPeriodicPublisherOptions & GeneralPeriodicOptions
+  export type CustomPeriodicPublisherOptions =
+    RequiredPeriodicPublisherOptions & CustomPeriodicOptions
+  export type PublishPeriodicallyOptions =
+    | GeneralPeriodicPublisherOptions
+    | CustomPeriodicPublisherOptions
+  export type PeriodicTimerFunctionOptions = {
+    timeDiff: number
+    callCount: number
+    stop: () => void
+  }
+  export type PeriodicTimerFunction = (
+    options: PeriodicTimerFunctionOptions,
+  ) => number
 }
-declare module "rendering/dom/tag" {
-    import type { JaxsElement, TagAttributes, TagEventAttributes, DomPublish, RenderKit } from "types";
-    export const createNode: (type: string, document: Document) => HTMLElement;
-    export const setAttributesOnElement: (element: Element, attributes: TagAttributes) => void;
-    export const setEventsOnElement: (element: JaxsElement, events: TagEventAttributes, publish: DomPublish) => void;
-    export const createDecoratedNode: (type: string, attributes: TagAttributes, events: TagEventAttributes, renderKit: RenderKit) => JaxsElement;
+declare module 'rendering/dom/tag' {
+  import type {
+    JaxsElement,
+    TagAttributes,
+    TagEventAttributes,
+    DomPublish,
+    RenderKit,
+  } from 'types'
+  export const createNode: (type: string, document: Document) => HTMLElement
+  export const setAttributesOnElement: (
+    element: Element,
+    attributes: TagAttributes,
+  ) => void
+  export const setEventsOnElement: (
+    element: JaxsElement,
+    events: TagEventAttributes,
+    publish: DomPublish,
+  ) => void
+  export const createDecoratedNode: (
+    type: string,
+    attributes: TagAttributes,
+    events: TagEventAttributes,
+    renderKit: RenderKit,
+  ) => JaxsElement
 }
-declare module "rendering/dom/svg" {
-    import type { TagAttributes, JaxsElement } from "types";
-    export const namespace = "http://www.w3.org/2000/svg";
-    export const isSvgTag: (tagType: string, attributeNamespace?: string) => boolean;
-    export const createSvgNode: (type: string, attributes: TagAttributes, document: Document) => JaxsElement;
-    export const elementIsSvg: (element: JaxsElement) => boolean;
+declare module 'rendering/dom/svg' {
+  import type { TagAttributes, JaxsElement } from 'types'
+  export const namespace = 'http://www.w3.org/2000/svg'
+  export const isSvgTag: (
+    tagType: string,
+    attributeNamespace?: string,
+  ) => boolean
+  export const createSvgNode: (
+    type: string,
+    attributes: TagAttributes,
+    document: Document,
+  ) => JaxsElement
+  export const elementIsSvg: (element: JaxsElement) => boolean
 }
-declare module "rendering/dom/text" {
-    export const createTextNode: (value: string, document: Document) => Text;
+declare module 'rendering/dom/text' {
+  export const createTextNode: (value: string, document: Document) => Text
 }
-declare module "rendering/templates/text" {
-    import { Renderable, TextValue, RenderKit } from "types";
-    export class TextTemplate implements Renderable {
-        value: string;
-        constructor(content: TextValue);
-        render(renderKit: RenderKit): Text[];
-    }
+declare module 'rendering/templates/text' {
+  import { Renderable, TextValue, RenderKit } from 'types'
+  export class TextTemplate implements Renderable {
+    value: string
+    constructor(content: TextValue)
+    render(renderKit: RenderKit): Text[]
+  }
 }
-declare module "rendering/templates/children/text" {
-    import { TextValue, Renderable } from "types";
-    import { TextTemplate } from "rendering/templates/text";
-    export const isTextValue: <T>(child: TextValue | T) => child is string | number | (T & string) | (T & number);
-    export const textNode: (content: TextValue) => TextTemplate;
-    export const replaceTextNodes: (child: TextValue | Renderable) => Renderable | TextTemplate;
+declare module 'rendering/templates/children/text' {
+  import { TextValue, Renderable } from 'types'
+  import { TextTemplate } from 'rendering/templates/text'
+  export const isTextValue: <T>(
+    child: TextValue | T,
+  ) => child is string | number | (T & string) | (T & number)
+  export const textNode: (content: TextValue) => TextTemplate
+  export const replaceTextNodes: (
+    child: TextValue | Renderable,
+  ) => Renderable | TextTemplate
 }
-declare module "rendering/templates/children/normalize" {
-    import { JsxCollection, AttributesWithChildren } from "types";
-    export const normalizeJsxChildren: (jsxChildren: JsxCollection) => (import("types").Renderable | import("rendering/templates/text").TextTemplate)[];
-    export const normalizeToArray: <T>(children: T | T[]) => T[];
-    export const ensureJsxChildrenArray: <T>(maybeChildren?: JsxCollection, attributes?: AttributesWithChildren<T>) => JsxCollection;
+declare module 'rendering/templates/children/normalize' {
+  import { JsxCollection, AttributesWithChildren } from 'types'
+  export const normalizeJsxChildren: (
+    jsxChildren: JsxCollection,
+  ) => (
+    | import('types').Renderable
+    | import('rendering/templates/text').TextTemplate
+  )[]
+  export const normalizeToArray: <T>(children: T | T[]) => T[]
+  export const ensureJsxChildrenArray: <T>(
+    maybeChildren?: JsxCollection,
+    attributes?: AttributesWithChildren<T>,
+  ) => JsxCollection
 }
-declare module "rendering/templates/tag/attributes-and-events" {
-    import type { Props, TagAttributesAndEvents, JsxCollection } from "types";
-    export const separateAttrsAndEvents: <T>(props: Props<T>, defaultValue?: string) => TagAttributesAndEvents;
-    export const packageJsxAttributes: <T>(maybeAttributes?: Props<T>, maybeChildren?: JsxCollection) => Props<T>;
+declare module 'rendering/templates/tag/attributes-and-events' {
+  import type { Props, TagAttributesAndEvents, JsxCollection } from 'types'
+  export const separateAttrsAndEvents: <T>(
+    props: Props<T>,
+    defaultValue?: string,
+  ) => TagAttributesAndEvents
+  export const packageJsxAttributes: <T>(
+    maybeAttributes?: Props<T>,
+    maybeChildren?: JsxCollection,
+  ) => Props<T>
 }
-declare module "rendering/templates/children/render" {
-    import { Renderable, RenderKit, JaxsNode, JaxsElement } from "types";
-    export const recursiveRender: (children: Renderable[], renderKit: RenderKit, parentElement?: JaxsElement, rendered?: JaxsNode[]) => JaxsNode[];
+declare module 'rendering/templates/children/render' {
+  import { Renderable, RenderKit, JaxsNode, JaxsElement } from 'types'
+  export const recursiveRender: (
+    children: Renderable[],
+    renderKit: RenderKit,
+    parentElement?: JaxsElement,
+    rendered?: JaxsNode[],
+  ) => JaxsNode[]
 }
-declare module "rendering/templates/children" {
-    import { JaxsElement, Renderable, JsxCollection, RenderKit, JaxsNodes, JaxsNode } from "types";
-    export class Children implements Renderable {
-        collection: Renderable[];
-        parentElement?: JaxsElement;
-        constructor(jsxChildren: JsxCollection);
-        render(renderKit: RenderKit, parentElement?: JaxsElement): JaxsNode[];
-        generateDom(renderKit: RenderKit): JaxsNode[];
-        attachToParent(dom: JaxsNodes): void;
-    }
+declare module 'rendering/templates/children' {
+  import {
+    JaxsElement,
+    Renderable,
+    JsxCollection,
+    RenderKit,
+    JaxsNodes,
+    JaxsNode,
+  } from 'types'
+  export class Children implements Renderable {
+    collection: Renderable[]
+    parentElement?: JaxsElement
+    constructor(jsxChildren: JsxCollection)
+    render(renderKit: RenderKit, parentElement?: JaxsElement): JaxsNode[]
+    generateDom(renderKit: RenderKit): JaxsNode[]
+    attachToParent(dom: JaxsNodes): void
+  }
 }
-declare module "rendering/templates/tag/jsx-key" {
-    import { TagAttributes } from "types";
-    export class JsxKey {
-        attributes: TagAttributes;
-        type: string;
-        constructor(type: string, attributes: TagAttributes);
-        generate(): string;
-        sourceKey(): string;
-        createKeyFromAttributes(): string;
-    }
+declare module 'rendering/templates/tag/jsx-key' {
+  import { TagAttributes } from 'types'
+  export class JsxKey {
+    attributes: TagAttributes
+    type: string
+    constructor(type: string, attributes: TagAttributes)
+    generate(): string
+    sourceKey(): string
+    createKeyFromAttributes(): string
+  }
 }
-declare module "rendering/templates/tag" {
-    import type { Props, JaxsNode, TagEventAttributes, Renderable, RenderKit, TagAttributes, JsxCollection } from "types";
-    import { Children } from "rendering/templates/children";
-    export class Tag<T> implements Renderable {
-        type: string;
-        events: TagEventAttributes;
-        attributes: TagAttributes;
-        props: Props<T>;
-        children: Children;
-        isSvg: boolean;
-        constructor(tagType: string, props: Props<T>, children?: JsxCollection);
-        render(renderKit: RenderKit): JaxsNode[];
-        generateDom(renderKit: RenderKit): import("types").JaxsElement;
-        generateHtmlDom(renderKit: RenderKit): import("types").JaxsElement;
-        generateSvgDom(renderKit: RenderKit): import("types").JaxsElement;
-        jsxKey(): string;
-    }
+declare module 'rendering/templates/tag' {
+  import type {
+    Props,
+    JaxsNode,
+    TagEventAttributes,
+    Renderable,
+    RenderKit,
+    TagAttributes,
+    JsxCollection,
+  } from 'types'
+  import { Children } from 'rendering/templates/children'
+  export class Tag<T> implements Renderable {
+    type: string
+    events: TagEventAttributes
+    attributes: TagAttributes
+    props: Props<T>
+    children: Children
+    isSvg: boolean
+    constructor(tagType: string, props: Props<T>, children?: JsxCollection)
+    render(renderKit: RenderKit): JaxsNode[]
+    generateDom(renderKit: RenderKit): import('types').JaxsElement
+    generateHtmlDom(renderKit: RenderKit): import('types').JaxsElement
+    generateSvgDom(renderKit: RenderKit): import('types').JaxsElement
+    jsxKey(): string
+  }
 }
-declare module "rendering/jsx" {
-    import type { JsxCollection, Props, Template, Renderable } from "types";
-    import { Children } from "rendering/templates/children";
-    const jsx: {
-        <T>(type: string | Template<T>, attributes: Props<T>, ...children: JsxCollection): Renderable;
-        fragment<T>(attributes: Props<T>, maybeChildren: JsxCollection): Children;
-    };
-    export { jsx };
+declare module 'rendering/jsx' {
+  import type { JsxCollection, Props, Template, Renderable } from 'types'
+  import { Children } from 'rendering/templates/children'
+  const jsx: {
+    <T>(
+      type: string | Template<T>,
+      attributes: Props<T>,
+      ...children: JsxCollection
+    ): Renderable
+    fragment<T>(attributes: Props<T>, maybeChildren: JsxCollection): Children
+  }
+  export { jsx }
 }
-declare module "app/builder" {
-    import { App } from "app/index";
-    import { JaxsBus } from "bus/index";
-    import { State } from "state/index";
-    import { PublishFunction, Subscribe, RenderKit, CreateAppBuilderArguments } from "types";
-    class AppBuilder {
-        window: Window;
-        document: Document;
-        publish: PublishFunction;
-        subscribe: Subscribe;
-        bus: JaxsBus;
-        state: State;
-        renderKit: RenderKit;
-        constructor(domEnvironment: CreateAppBuilderArguments);
-        setup(): App;
-        setupDomEnvironment(domEnvironment: CreateAppBuilderArguments): void;
-        setupBus(): void;
-        setupState(): void;
-        addBusOptions(): void;
-        setRenderKit(): void;
-    }
-    const createApp: (domEnvironment?: CreateAppBuilderArguments) => App;
-    export { App, AppBuilder, createApp };
+declare module 'app/builder' {
+  import { App } from 'app/index'
+  import { JaxsBus } from 'bus/index'
+  import { State } from 'state/index'
+  import {
+    PublishFunction,
+    Subscribe,
+    RenderKit,
+    CreateAppBuilderArguments,
+  } from 'types'
+  class AppBuilder {
+    window: Window
+    document: Document
+    publish: PublishFunction
+    subscribe: Subscribe
+    bus: JaxsBus
+    state: State
+    renderKit: RenderKit
+    constructor(domEnvironment: CreateAppBuilderArguments)
+    setup(): App
+    setupDomEnvironment(domEnvironment: CreateAppBuilderArguments): void
+    setupBus(): void
+    setupState(): void
+    addBusOptions(): void
+    setRenderKit(): void
+  }
+  const createApp: (domEnvironment?: CreateAppBuilderArguments) => App
+  export { App, AppBuilder, createApp }
 }
-declare module "rendering/update/instructions/instructions" {
-    import { JaxsInput, ChangeInstruction, JaxsElement, RemoveInstructionData, AttributeInstructionData, EventInstructionData, UpdateEventInstructionData, InsertNodeData } from "types";
-    export const changeText: (source: Text, target: Text) => ChangeInstruction;
-    export const replaceNode: (source: JaxsElement, target: JaxsElement) => ChangeInstruction;
-    export const removeAttribute: (source: JaxsElement, target: JaxsElement, data: RemoveInstructionData) => ChangeInstruction;
-    export const addAttribute: (source: JaxsElement, target: JaxsElement, data: AttributeInstructionData) => ChangeInstruction;
-    export const updateAttribute: (source: JaxsElement, target: JaxsElement, data: AttributeInstructionData) => ChangeInstruction;
-    export const removeEvent: (source: JaxsElement, target: JaxsElement, data: EventInstructionData) => ChangeInstruction;
-    export const addEvent: (source: JaxsElement, target: JaxsElement, data: EventInstructionData) => ChangeInstruction;
-    export const updateEvent: (source: JaxsElement, target: JaxsElement, data: UpdateEventInstructionData) => ChangeInstruction;
-    export const removeNode: (source: JaxsElement) => ChangeInstruction;
-    export const insertNode: (target: JaxsElement, data: InsertNodeData) => ChangeInstruction;
-    export const changeValue: (source: JaxsInput, target: JaxsInput, data: AttributeInstructionData) => ChangeInstruction;
-    export const instructionsSorter: (left: ChangeInstruction, right: ChangeInstruction) => 0 | 1 | -1;
+declare module 'rendering/update/instructions/instructions' {
+  import {
+    JaxsInput,
+    ChangeInstruction,
+    JaxsElement,
+    RemoveInstructionData,
+    AttributeInstructionData,
+    EventInstructionData,
+    UpdateEventInstructionData,
+    InsertNodeData,
+  } from 'types'
+  export const changeText: (source: Text, target: Text) => ChangeInstruction
+  export const replaceNode: (
+    source: JaxsElement,
+    target: JaxsElement,
+  ) => ChangeInstruction
+  export const removeAttribute: (
+    source: JaxsElement,
+    target: JaxsElement,
+    data: RemoveInstructionData,
+  ) => ChangeInstruction
+  export const addAttribute: (
+    source: JaxsElement,
+    target: JaxsElement,
+    data: AttributeInstructionData,
+  ) => ChangeInstruction
+  export const updateAttribute: (
+    source: JaxsElement,
+    target: JaxsElement,
+    data: AttributeInstructionData,
+  ) => ChangeInstruction
+  export const removeEvent: (
+    source: JaxsElement,
+    target: JaxsElement,
+    data: EventInstructionData,
+  ) => ChangeInstruction
+  export const addEvent: (
+    source: JaxsElement,
+    target: JaxsElement,
+    data: EventInstructionData,
+  ) => ChangeInstruction
+  export const updateEvent: (
+    source: JaxsElement,
+    target: JaxsElement,
+    data: UpdateEventInstructionData,
+  ) => ChangeInstruction
+  export const removeNode: (source: JaxsElement) => ChangeInstruction
+  export const insertNode: (
+    target: JaxsElement,
+    data: InsertNodeData,
+  ) => ChangeInstruction
+  export const changeValue: (
+    source: JaxsInput,
+    target: JaxsInput,
+    data: AttributeInstructionData,
+  ) => ChangeInstruction
+  export const instructionsSorter: (
+    left: ChangeInstruction,
+    right: ChangeInstruction,
+  ) => 0 | 1 | -1
 }
-declare module "rendering/update/instructions/id-map" {
-    import type { JaxsNode, JaxsNodes, JsxChangeId } from "types";
-    export class IdMap {
-        map: Record<string, JsxChangeId[]>;
-        constructor();
-        populate(list: JaxsNodes): void;
-        pullMatch(element: JaxsNode): JsxChangeId;
-        clear(element: JaxsNode): void;
-        check(element: JaxsNode): boolean;
-        remaining(): JsxChangeId[];
-    }
-    export const createIdMap: (list: JaxsNodes) => IdMap;
+declare module 'rendering/update/instructions/id-map' {
+  import type { JaxsNode, JaxsNodes, JsxChangeId } from 'types'
+  export class IdMap {
+    map: Record<string, JsxChangeId[]>
+    constructor()
+    populate(list: JaxsNodes): void
+    pullMatch(element: JaxsNode): JsxChangeId
+    clear(element: JaxsNode): void
+    check(element: JaxsNode): boolean
+    remaining(): JsxChangeId[]
+  }
+  export const createIdMap: (list: JaxsNodes) => IdMap
 }
-declare module "rendering/update/instructions/nodes/element/attributes" {
-    import type { JaxsElement, ChangeInstructions } from "types";
-    export const compileForAttributes: (source: JaxsElement, target: JaxsElement, isSvg?: boolean) => ChangeInstructions;
+declare module 'rendering/update/instructions/nodes/element/attributes' {
+  import type { JaxsElement, ChangeInstructions } from 'types'
+  export const compileForAttributes: (
+    source: JaxsElement,
+    target: JaxsElement,
+    isSvg?: boolean,
+  ) => ChangeInstructions
 }
-declare module "rendering/update/instructions/nodes/element/events" {
-    import type { JaxsElement, ChangeInstructions } from "types";
-    export const compileForEvents: (source: JaxsElement, target: JaxsElement) => ChangeInstructions;
+declare module 'rendering/update/instructions/nodes/element/events' {
+  import type { JaxsElement, ChangeInstructions } from 'types'
+  export const compileForEvents: (
+    source: JaxsElement,
+    target: JaxsElement,
+  ) => ChangeInstructions
 }
-declare module "rendering/update/instructions/nodes/input" {
-    import { ChangeInstructions, JaxsElement } from "types";
-    export const compileForInputValue: (sourceElement: JaxsElement, targetElement: JaxsElement) => ChangeInstructions;
+declare module 'rendering/update/instructions/nodes/input' {
+  import { ChangeInstructions, JaxsElement } from 'types'
+  export const compileForInputValue: (
+    sourceElement: JaxsElement,
+    targetElement: JaxsElement,
+  ) => ChangeInstructions
 }
-declare module "rendering/update/instructions/nodes/element" {
-    import type { JaxsElement } from "types";
-    export const compileForElement: (source: JaxsElement, target: JaxsElement) => import("types").ChangeInstruction[];
+declare module 'rendering/update/instructions/nodes/element' {
+  import type { JaxsElement } from 'types'
+  export const compileForElement: (
+    source: JaxsElement,
+    target: JaxsElement,
+  ) => import('types').ChangeInstruction[]
 }
-declare module "rendering/update/instructions/nodes/svg" {
-    import { JaxsElement } from "types";
-    export const compileForSvg: (source: JaxsElement, target: JaxsElement) => import("types").ChangeInstructions;
+declare module 'rendering/update/instructions/nodes/svg' {
+  import { JaxsElement } from 'types'
+  export const compileForSvg: (
+    source: JaxsElement,
+    target: JaxsElement,
+  ) => import('types').ChangeInstructions
 }
-declare module "rendering/update/instructions/nodes/text" {
-    import type { ChangeInstructions } from "types";
-    export const compileForText: (source: Text, target: Text) => ChangeInstructions;
+declare module 'rendering/update/instructions/nodes/text' {
+  import type { ChangeInstructions } from 'types'
+  export const compileForText: (
+    source: Text,
+    target: Text,
+  ) => ChangeInstructions
 }
-declare module "rendering/update/instructions/node" {
-    import type { JaxsNode, ChangeInstructions, CompileChildren } from "types";
-    export const compileForNode: (source: JaxsNode, target: JaxsNode, compileChildren: CompileChildren) => ChangeInstructions;
+declare module 'rendering/update/instructions/node' {
+  import type { JaxsNode, ChangeInstructions, CompileChildren } from 'types'
+  export const compileForNode: (
+    source: JaxsNode,
+    target: JaxsNode,
+    compileChildren: CompileChildren,
+  ) => ChangeInstructions
 }
-declare module "rendering/update/instructions/collection" {
-    import type { JaxsElement, JaxsNodes } from "types";
-    export const compileCollection: (sourceList: JaxsNodes, targetList: JaxsNodes, parent: JaxsElement) => import("types").ChangeInstruction[];
+declare module 'rendering/update/instructions/collection' {
+  import type { JaxsElement, JaxsNodes } from 'types'
+  export const compileCollection: (
+    sourceList: JaxsNodes,
+    targetList: JaxsNodes,
+    parent: JaxsElement,
+  ) => import('types').ChangeInstruction[]
 }
-declare module "rendering/update/perform-change" {
-    import type { ChangeInstruction, JaxsElement, JaxsNodes } from "types";
-    export const performChange: (source: JaxsNodes, target: JaxsNodes, parent: JaxsElement) => ChangeInstruction[];
+declare module 'rendering/update/perform-change' {
+  import type { ChangeInstruction, JaxsElement, JaxsNodes } from 'types'
+  export const performChange: (
+    source: JaxsNodes,
+    target: JaxsNodes,
+    parent: JaxsElement,
+  ) => ChangeInstruction[]
 }
-declare module "rendering/templates/bound/modify-dom-cache" {
-    import { ChangeInstructions, JaxsNode, JaxsElement } from "types";
-    export const modifyDomCache: (instructions: ChangeInstructions, dom: JaxsNode[], parentElement: JaxsElement) => JaxsNode[];
+declare module 'rendering/templates/bound/modify-dom-cache' {
+  import { ChangeInstructions, JaxsNode, JaxsElement } from 'types'
+  export const modifyDomCache: (
+    instructions: ChangeInstructions,
+    dom: JaxsNode[],
+    parentElement: JaxsElement,
+  ) => JaxsNode[]
 }
-declare module "rendering/templates/bound" {
-    import { JaxsElement, Props, Template, RenderKit, ViewModel, BindParams, BindSubscriptionList, JaxsNode } from "types";
-    export class Bound<ATTRIBUTES, STATE_MAP> {
-        Template: Template<ATTRIBUTES>;
-        viewModel: ViewModel<ATTRIBUTES, STATE_MAP>;
-        attributes: Partial<Props<ATTRIBUTES>>;
-        subscriptions: BindSubscriptionList;
-        dom: JaxsNode[];
-        parentElement: JaxsElement | null;
-        renderKit?: RenderKit;
-        constructor({ Template, subscriptions, attributes, viewModel }: {
-            Template: any;
-            subscriptions: any;
-            attributes: any;
-            viewModel: any;
-        });
-        render(renderKit: RenderKit): JaxsNode[];
-        generateDom(renderKit: RenderKit): JaxsNode[];
-        rerender(): void;
-        subscribeForRerender(): void;
-        eventName(storeName: string): string;
-    }
-    export const bind: <ATTRIBUTES, STATE_MAP>({ Template, viewModel, subscriptions, }: BindParams<ATTRIBUTES, STATE_MAP>) => (attributes: Partial<Props<ATTRIBUTES>>) => Bound<unknown, unknown>;
+declare module 'rendering/templates/bound' {
+  import {
+    JaxsElement,
+    Props,
+    Template,
+    RenderKit,
+    ViewModel,
+    BindParams,
+    BindSubscriptionList,
+    JaxsNode,
+  } from 'types'
+  export class Bound<ATTRIBUTES, STATE_MAP> {
+    Template: Template<ATTRIBUTES>
+    viewModel: ViewModel<ATTRIBUTES, STATE_MAP>
+    attributes: Partial<Props<ATTRIBUTES>>
+    subscriptions: BindSubscriptionList
+    dom: JaxsNode[]
+    parentElement: JaxsElement | null
+    renderKit?: RenderKit
+    constructor({
+      Template,
+      subscriptions,
+      attributes,
+      viewModel,
+    }: {
+      Template: any
+      subscriptions: any
+      attributes: any
+      viewModel: any
+    })
+    render(renderKit: RenderKit): JaxsNode[]
+    generateDom(renderKit: RenderKit): JaxsNode[]
+    rerender(): void
+    subscribeForRerender(): void
+    eventName(storeName: string): string
+  }
+  export const bind: <ATTRIBUTES, STATE_MAP>({
+    Template,
+    viewModel,
+    subscriptions,
+  }: BindParams<ATTRIBUTES, STATE_MAP>) => (
+    attributes: Partial<Props<ATTRIBUTES>>,
+  ) => Bound<unknown, unknown>
 }
-declare module "navigation/index" {
-    import * as events from "navigation/events";
-    import { extractQueryParams } from "navigation/extract-query-params";
-    import { findHref } from "navigation/find-href";
-    import { navigate } from "navigation/navigate";
-    import { onLinkClick } from "navigation/on-link-click";
-    import { onLocationChange } from "navigation/on-location-change";
-    import { createRouteState } from "navigation/route-state";
-    import * as start from "navigation/start";
-    export { events, extractQueryParams, findHref, navigate, onLinkClick, onLocationChange, createRouteState, start, };
+declare module 'navigation/index' {
+  import * as events from 'navigation/events'
+  import { extractQueryParams } from 'navigation/extract-query-params'
+  import { findHref } from 'navigation/find-href'
+  import { navigate } from 'navigation/navigate'
+  import { onLinkClick } from 'navigation/on-link-click'
+  import { onLocationChange } from 'navigation/on-location-change'
+  import { createRouteState } from 'navigation/route-state'
+  import * as start from 'navigation/start'
+  export {
+    events,
+    extractQueryParams,
+    findHref,
+    navigate,
+    onLinkClick,
+    onLocationChange,
+    createRouteState,
+    start,
+  }
 }
-declare module "app/routing" {
-    import { RenderedRoute, RouteMatcher } from "types";
-    export const exactPathMatch: (exactPath: string) => RouteMatcher;
-    export const catchAll: RouteMatcher;
-    export const buildRouter: (pages: RenderedRoute[]) => ({ route }: {
-        route: any;
-    }) => import("types").StaticTemplate;
+declare module 'app/routing' {
+  import { RenderedRoute, RouteMatcher } from 'types'
+  export const exactPathMatch: (exactPath: string) => RouteMatcher
+  export const catchAll: RouteMatcher
+  export const buildRouter: (
+    pages: RenderedRoute[],
+  ) => ({ route }: { route: any }) => import('types').StaticTemplate
 }
-declare module "rendering/null" {
-    import { RenderKit, JaxsElement, JaxsNode } from "types";
-    export const NullTemplate: () => {
-        render: (renderKit: RenderKit, parentElement?: JaxsElement) => JaxsNode[];
-    };
+declare module 'rendering/null' {
+  import { RenderKit, JaxsElement, JaxsNode } from 'types'
+  export const NullTemplate: () => {
+    render: (renderKit: RenderKit, parentElement?: JaxsElement) => JaxsNode[]
+  }
 }
-declare module "app/routed-view" {
-    import { RenderedRoute, RouteState } from "types";
-    export const routedView: (routes: RenderedRoute[]) => (attributes: Partial<import("types").Props<{
-        route: RouteState;
-    }>>) => import("rendering/templates/bound").Bound<unknown, unknown>;
+declare module 'app/routed-view' {
+  import { RenderedRoute, RouteState } from 'types'
+  export const routedView: (routes: RenderedRoute[]) => (
+    attributes: Partial<
+      import('types').Props<{
+        route: RouteState
+      }>
+    >,
+  ) => import('rendering/templates/bound').Bound<unknown, unknown>
 }
-declare module "jaxs" {
-    export { jsx } from "rendering/jsx";
-    export { createApp } from "app/builder";
-    export { bind } from "rendering/templates/bound";
-    export * as JaxsTypes from "types";
-    export * as navigation from "navigation/index";
-    export * as appBuilding from "app/index";
-    export * as messageBus from "bus/index";
-    export * as state from "state/index";
-    export * as routing from "app/routing";
-    export { routedView } from "app/routed-view";
+declare module 'jaxs' {
+  export { jsx } from 'rendering/jsx'
+  export { createApp } from 'app/builder'
+  export { bind } from 'rendering/templates/bound'
+  export * as JaxsTypes from 'types'
+  export * as navigation from 'navigation/index'
+  export * as appBuilding from 'app/index'
+  export * as messageBus from 'bus/index'
+  export * as state from 'state/index'
+  export * as routing from 'app/routing'
+  export { routedView } from 'app/routed-view'
 }

--- a/dist/jaxs.js
+++ b/dist/jaxs.js
@@ -1,643 +1,805 @@
-const Z = (e, t) => t.createElement(e), tt = (e, t) => {
-  for (const s in t) {
-    if (s === "__self") continue;
-    const r = t[s].toString();
-    if (s === "value") {
-      const n = e;
-      n.value !== r && (n.value = r);
-    } else
-      e.setAttribute(s, r);
-  }
-}, et = (e, t, s) => {
-  const r = {};
-  for (const n in t) {
-    const i = t[n], a = (l) => s(i, l);
-    e.addEventListener(n, a), r[n] = {
-      domEvent: n,
-      busEvent: i,
-      listener: a
-    };
-  }
-  e.eventMaps = r;
-}, st = (e, t, s, r) => {
-  const n = Z(e, r.document);
-  return tt(n, t), et(n, s, r.publish), n;
-}, y = "http://www.w3.org/2000/svg", rt = {
-  animate: !0,
-  animateMotion: !0,
-  animateTransform: !0,
-  circle: !0,
-  clipPath: !0,
-  defs: !0,
-  desc: !0,
-  ellipse: !0,
-  feBlend: !0,
-  feColorMatrix: !0,
-  feComponentTransfer: !0,
-  feComposite: !0,
-  feConvolveMatrix: !0,
-  feDiffuseLighting: !0,
-  feDisplacementMap: !0,
-  feDistantLight: !0,
-  feDropShadow: !0,
-  feFlood: !0,
-  feFuncA: !0,
-  feFuncB: !0,
-  feFuncG: !0,
-  feFuncR: !0,
-  feGaussianBlur: !0,
-  feImage: !0,
-  feMerge: !0,
-  feMergeNode: !0,
-  feMorphology: !0,
-  feOffset: !0,
-  fePointLight: !0,
-  feSpecularLighting: !0,
-  feSpotLight: !0,
-  feTile: !0,
-  feTurbulence: !0,
-  filter: !0,
-  foreignObject: !0,
-  g: !0,
-  image: !0,
-  line: !0,
-  linearGradient: !0,
-  marker: !0,
-  mask: !0,
-  metadata: !0,
-  mpath: !0,
-  path: !0,
-  pattern: !0,
-  polygon: !0,
-  polyline: !0,
-  radialGradient: !0,
-  rect: !0,
-  script: !0,
-  set: !0,
-  stop: !0,
-  style: !0,
-  svg: !0,
-  switch: !0,
-  symbol: !0,
-  text: !0,
-  textPath: !0,
-  title: !0,
-  tspan: !0,
-  use: !0,
-  view: !0
-}, nt = (e, t) => !!(rt[e] || e === "a" && t === y), it = (e, t, s) => {
-  const r = s.createElementNS(y, e);
-  for (const n in t)
-    n === "__self" || n === "xmlns" || r.setAttributeNS(null, n, t[n].toString());
-  return r;
-}, ot = (e) => e.namespaceURI === y, ut = (e, t) => t.createTextNode(e);
+const Z = (e, t) => t.createElement(e),
+  tt = (e, t) => {
+    for (const s in t) {
+      if (s === '__self') continue
+      const r = t[s].toString()
+      if (s === 'value') {
+        const n = e
+        n.value !== r && (n.value = r)
+      } else e.setAttribute(s, r)
+    }
+  },
+  et = (e, t, s) => {
+    const r = {}
+    for (const n in t) {
+      const i = t[n],
+        a = (l) => s(i, l)
+      e.addEventListener(n, a),
+        (r[n] = {
+          domEvent: n,
+          busEvent: i,
+          listener: a,
+        })
+    }
+    e.eventMaps = r
+  },
+  st = (e, t, s, r) => {
+    const n = Z(e, r.document)
+    return tt(n, t), et(n, s, r.publish), n
+  },
+  y = 'http://www.w3.org/2000/svg',
+  rt = {
+    animate: !0,
+    animateMotion: !0,
+    animateTransform: !0,
+    circle: !0,
+    clipPath: !0,
+    defs: !0,
+    desc: !0,
+    ellipse: !0,
+    feBlend: !0,
+    feColorMatrix: !0,
+    feComponentTransfer: !0,
+    feComposite: !0,
+    feConvolveMatrix: !0,
+    feDiffuseLighting: !0,
+    feDisplacementMap: !0,
+    feDistantLight: !0,
+    feDropShadow: !0,
+    feFlood: !0,
+    feFuncA: !0,
+    feFuncB: !0,
+    feFuncG: !0,
+    feFuncR: !0,
+    feGaussianBlur: !0,
+    feImage: !0,
+    feMerge: !0,
+    feMergeNode: !0,
+    feMorphology: !0,
+    feOffset: !0,
+    fePointLight: !0,
+    feSpecularLighting: !0,
+    feSpotLight: !0,
+    feTile: !0,
+    feTurbulence: !0,
+    filter: !0,
+    foreignObject: !0,
+    g: !0,
+    image: !0,
+    line: !0,
+    linearGradient: !0,
+    marker: !0,
+    mask: !0,
+    metadata: !0,
+    mpath: !0,
+    path: !0,
+    pattern: !0,
+    polygon: !0,
+    polyline: !0,
+    radialGradient: !0,
+    rect: !0,
+    script: !0,
+    set: !0,
+    stop: !0,
+    style: !0,
+    svg: !0,
+    switch: !0,
+    symbol: !0,
+    text: !0,
+    textPath: !0,
+    title: !0,
+    tspan: !0,
+    use: !0,
+    view: !0,
+  },
+  nt = (e, t) => !!(rt[e] || (e === 'a' && t === y)),
+  it = (e, t, s) => {
+    const r = s.createElementNS(y, e)
+    for (const n in t)
+      n === '__self' ||
+        n === 'xmlns' ||
+        r.setAttributeNS(null, n, t[n].toString())
+    return r
+  },
+  ot = (e) => e.namespaceURI === y,
+  ut = (e, t) => t.createTextNode(e)
 class at {
   constructor(t) {
-    this.value = t.toString();
+    this.value = t.toString()
   }
   render(t) {
-    const s = ut(this.value, t.document);
-    return s.__jsx = "TextNode", [s];
+    const s = ut(this.value, t.document)
+    return (s.__jsx = 'TextNode'), [s]
   }
 }
-const ct = (e) => typeof e == "string" || typeof e == "number", lt = (e) => new at(e), ht = (e) => ct(e) ? lt(e) : e, dt = (e) => pt(e).map(ht).flat(), pt = (e) => Array.isArray(e) ? e.flat() : e ? [e] : [], T = (e, t = {}) => e || t.children || [], mt = (e, t = "") => {
-  const s = {}, r = {};
-  for (const n in e) {
-    const i = e[n];
-    if (n.match(/^on.+/i)) {
-      const a = n.slice(2).toLowerCase();
-      r[a] = i ? i.toString() : "";
-    } else {
-      if (i === !1) continue;
-      n === "__source" ? s.__source = e.__source : s[n] = ft(n, i, t);
+const ct = (e) => typeof e == 'string' || typeof e == 'number',
+  lt = (e) => new at(e),
+  ht = (e) => (ct(e) ? lt(e) : e),
+  dt = (e) => pt(e).map(ht).flat(),
+  pt = (e) => (Array.isArray(e) ? e.flat() : e ? [e] : []),
+  T = (e, t = {}) => e || t.children || [],
+  mt = (e, t = '') => {
+    const s = {},
+      r = {}
+    for (const n in e) {
+      const i = e[n]
+      if (n.match(/^on.+/i)) {
+        const a = n.slice(2).toLowerCase()
+        r[a] = i ? i.toString() : ''
+      } else {
+        if (i === !1) continue
+        n === '__source' ? (s.__source = e.__source) : (s[n] = ft(n, i, t))
+      }
     }
-  }
-  return {
-    attributes: s,
-    events: r
-  };
-}, ft = (e, t, s = "") => t == null ? s : t.toString(), bt = (e, t) => {
-  const s = e || {}, r = T(t, s);
-  return s.children = s.children || r, s;
-}, j = (e, t, s, r = []) => e.reduce(vt(t, s), r).flat(), vt = (e, t) => (s, r) => r ? Array.isArray(r) ? j(
-  r,
-  e,
-  t,
-  s
-) : (r.render(e, t).forEach((n) => s.push(n)), s) : s;
+    return {
+      attributes: s,
+      events: r,
+    }
+  },
+  ft = (e, t, s = '') => (t == null ? s : t.toString()),
+  bt = (e, t) => {
+    const s = e || {},
+      r = T(t, s)
+    return (s.children = s.children || r), s
+  },
+  j = (e, t, s, r = []) => e.reduce(vt(t, s), r).flat(),
+  vt = (e, t) => (s, r) =>
+    r
+      ? Array.isArray(r)
+        ? j(r, e, t, s)
+        : (r.render(e, t).forEach((n) => s.push(n)), s)
+      : s
 class O {
   constructor(t) {
-    this.collection = dt(t);
+    this.collection = dt(t)
   }
   render(t, s) {
-    this.parentElement = s;
-    const r = this.generateDom(t);
-    return this.attachToParent(r), r;
+    this.parentElement = s
+    const r = this.generateDom(t)
+    return this.attachToParent(r), r
   }
   generateDom(t) {
-    return j(this.collection, t, this.parentElement);
+    return j(this.collection, t, this.parentElement)
   }
   attachToParent(t) {
-    if (this.parentElement === void 0) return;
-    const s = this.parentElement;
-    t.forEach((r) => s.appendChild(r));
+    if (this.parentElement === void 0) return
+    const s = this.parentElement
+    t.forEach((r) => s.appendChild(r))
   }
 }
 class gt {
   constructor(t, s) {
-    this.type = t, this.attributes = s;
+    ;(this.type = t), (this.attributes = s)
   }
   generate() {
-    return this.attributes.key || this.sourceKey() || this.createKeyFromAttributes();
+    return (
+      this.attributes.key || this.sourceKey() || this.createKeyFromAttributes()
+    )
   }
   sourceKey() {
     if (this.attributes.__source) {
-      const { fileName: t, lineNumber: s, columnNumber: r } = this.attributes.__source;
-      return `${t}:${s}:${r}`;
+      const {
+        fileName: t,
+        lineNumber: s,
+        columnNumber: r,
+      } = this.attributes.__source
+      return `${t}:${s}:${r}`
     }
   }
   createKeyFromAttributes() {
-    const t = this.attributes.id ? `#${this.attributes.id}` : "", s = this.attributes.type ? `[type=${this.attributes.type}]` : "", r = this.attributes.name ? `[name=${this.attributes.name}]` : "";
-    return `${this.type}${t}${s}${r}`;
+    const t = this.attributes.id ? `#${this.attributes.id}` : '',
+      s = this.attributes.type ? `[type=${this.attributes.type}]` : '',
+      r = this.attributes.name ? `[name=${this.attributes.name}]` : ''
+    return `${this.type}${t}${s}${r}`
   }
 }
 class yt {
   constructor(t, s, r = []) {
-    this.type = t;
-    const { events: n, attributes: i } = mt(s);
-    this.events = n, this.attributes = i, this.isSvg = nt(this.type, this.attributes.xmlns), this.children = new O(r);
+    this.type = t
+    const { events: n, attributes: i } = mt(s)
+    ;(this.events = n),
+      (this.attributes = i),
+      (this.isSvg = nt(this.type, this.attributes.xmlns)),
+      (this.children = new O(r))
   }
   render(t) {
-    const s = this.generateDom(t);
-    return s ? (this.children.render(t, s), [s]) : [];
+    const s = this.generateDom(t)
+    return s ? (this.children.render(t, s), [s]) : []
   }
   generateDom(t) {
-    return this.isSvg ? this.generateSvgDom(t) : this.generateHtmlDom(t);
+    return this.isSvg ? this.generateSvgDom(t) : this.generateHtmlDom(t)
   }
   generateHtmlDom(t) {
-    const s = st(
-      this.type,
-      this.attributes,
-      this.events,
-      t
-    );
-    return s.__jsx = this.jsxKey(), s;
+    const s = st(this.type, this.attributes, this.events, t)
+    return (s.__jsx = this.jsxKey()), s
   }
   generateSvgDom(t) {
-    const s = it(this.type, this.attributes, t.document);
-    return s.__jsx = this.jsxKey(), s;
+    const s = it(this.type, this.attributes, t.document)
+    return (s.__jsx = this.jsxKey()), s
   }
   jsxKey() {
-    return new gt(this.type, this.attributes).generate();
+    return new gt(this.type, this.attributes).generate()
   }
 }
-const Et = (e, t, ...s) => typeof e == "string" ? new yt(e, t, s) : e(bt(t, s));
+const Et = (e, t, ...s) =>
+  typeof e == 'string' ? new yt(e, t, s) : e(bt(t, s))
 Et.fragment = (e, t) => {
-  const s = T(t, e);
-  return new O(s);
-};
+  const s = T(t, e)
+  return new O(s)
+}
 class xt {
   constructor(t, s, r) {
-    this.template = t, this.selector = s, this.renderKit = r, this.dom = [];
+    ;(this.template = t),
+      (this.selector = s),
+      (this.renderKit = r),
+      (this.dom = [])
   }
   renderAndAttach(t) {
-    this.parentElement = this.getParentElement(), this.dom = this.render({ ...t, parent: this.parentElement }), this.parentElement && this.attach();
+    ;(this.parentElement = this.getParentElement()),
+      (this.dom = this.render({ ...t, parent: this.parentElement })),
+      this.parentElement && this.attach()
   }
   render(t) {
-    return this.template.render(t);
+    return this.template.render(t)
   }
   attach() {
-    this.parentElement && (this.parentElement.innerHTML = ""), this.dom.forEach((t) => {
-      this.parentElement && this.parentElement.appendChild(t);
-    });
+    this.parentElement && (this.parentElement.innerHTML = ''),
+      this.dom.forEach((t) => {
+        this.parentElement && this.parentElement.appendChild(t)
+      })
   }
   getParentElement() {
-    return this.renderKit.document.querySelector(this.selector);
+    return this.renderKit.document.querySelector(this.selector)
   }
 }
 const At = (e, t, s) => {
-  const r = new xt(e, t, s);
-  return r.renderAndAttach(s), r;
-}, M = "go-to-href", k = "go-to", m = "navigation:location-change", $ = "navigation:route-change", wt = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
-  __proto__: null,
-  linkNavigationEvent: M,
-  locationChangeEvent: m,
-  navigationEvent: k,
-  routeChangeEvent: $
-}, Symbol.toStringTag, { value: "Module" })), D = (e) => {
-  e.create("route", {
-    host: "",
-    path: "",
-    query: {}
-  });
-}, P = (e) => {
-  const t = e.closest("[href]");
-  return t && t.getAttribute("href") || "";
-}, E = (e, { publish: t, window: s }) => {
-  s.history.pushState(null, "", e), t(m, null);
-}, V = (e, t) => {
-  if (!e || !e.target) return;
-  e.preventDefault();
-  const s = P(e.target);
-  E(s, t);
-}, F = (e) => e.replace(/^\?/, "").split("&").reduce((t, s) => {
-  if (!s) return t;
-  const r = s.split("=");
-  return t[r[0]] = r[1], t;
-}, {}), L = (e, t) => {
-  const { state: s, publish: r, window: n } = t, { host: i, pathname: a, search: l } = n.location, u = a, d = F(l), c = {
-    host: i,
-    path: u,
-    query: d
-  };
-  s.store("route").update(c), r($, c);
-}, z = (e) => {
-  const { subscribe: t } = e;
-  t(M, V), t(k, (s, r) => {
-    E(s, r);
-  });
-}, B = (e) => {
-  const { publish: t, subscribe: s, state: r, window: n } = e;
-  D(r), n.addEventListener("popstate", () => t(m, null)), s(m, L);
-}, K = (e) => {
-  setTimeout(() => e.publish(m, null), 0);
-}, R = (e) => {
-  B(e), z(e), K(e);
-}, Nt = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
-  __proto__: null,
-  publishLocation: K,
-  startNavigation: R,
-  subscribeToHistoryChange: B,
-  subscribeToNavigation: z
-}, Symbol.toStringTag, { value: "Module" }));
+    const r = new xt(e, t, s)
+    return r.renderAndAttach(s), r
+  },
+  M = 'go-to-href',
+  k = 'go-to',
+  m = 'navigation:location-change',
+  $ = 'navigation:route-change',
+  wt = /* @__PURE__ */ Object.freeze(
+    /* @__PURE__ */ Object.defineProperty(
+      {
+        __proto__: null,
+        linkNavigationEvent: M,
+        locationChangeEvent: m,
+        navigationEvent: k,
+        routeChangeEvent: $,
+      },
+      Symbol.toStringTag,
+      { value: 'Module' },
+    ),
+  ),
+  D = (e) => {
+    e.create('route', {
+      host: '',
+      path: '',
+      query: {},
+    })
+  },
+  P = (e) => {
+    const t = e.closest('[href]')
+    return (t && t.getAttribute('href')) || ''
+  },
+  E = (e, { publish: t, window: s }) => {
+    s.history.pushState(null, '', e), t(m, null)
+  },
+  V = (e, t) => {
+    if (!e || !e.target) return
+    e.preventDefault()
+    const s = P(e.target)
+    E(s, t)
+  },
+  F = (e) =>
+    e
+      .replace(/^\?/, '')
+      .split('&')
+      .reduce((t, s) => {
+        if (!s) return t
+        const r = s.split('=')
+        return (t[r[0]] = r[1]), t
+      }, {}),
+  L = (e, t) => {
+    const { state: s, publish: r, window: n } = t,
+      { host: i, pathname: a, search: l } = n.location,
+      u = a,
+      d = F(l),
+      c = {
+        host: i,
+        path: u,
+        query: d,
+      }
+    s.store('route').update(c), r($, c)
+  },
+  z = (e) => {
+    const { subscribe: t } = e
+    t(M, V),
+      t(k, (s, r) => {
+        E(s, r)
+      })
+  },
+  B = (e) => {
+    const { publish: t, subscribe: s, state: r, window: n } = e
+    D(r), n.addEventListener('popstate', () => t(m, null)), s(m, L)
+  },
+  K = (e) => {
+    setTimeout(() => e.publish(m, null), 0)
+  },
+  R = (e) => {
+    B(e), z(e), K(e)
+  },
+  Nt = /* @__PURE__ */ Object.freeze(
+    /* @__PURE__ */ Object.defineProperty(
+      {
+        __proto__: null,
+        publishLocation: K,
+        startNavigation: R,
+        subscribeToHistoryChange: B,
+        subscribeToNavigation: z,
+      },
+      Symbol.toStringTag,
+      { value: 'Module' },
+    ),
+  )
 class U {
-  constructor({ window: t, document: s, publish: r, subscribe: n, bus: i, state: a, renderKit: l }) {
-    this.window = t, this.document = s, this.publish = r, this.subscribe = n, this.bus = i, this.state = a, this.renderKit = l, this.roots = [];
+  constructor({
+    window: t,
+    document: s,
+    publish: r,
+    subscribe: n,
+    bus: i,
+    state: a,
+    renderKit: l,
+  }) {
+    ;(this.window = t),
+      (this.document = s),
+      (this.publish = r),
+      (this.subscribe = n),
+      (this.bus = i),
+      (this.state = a),
+      (this.renderKit = l),
+      (this.roots = [])
   }
   render(t, s) {
-    const r = At(t, s, this.renderKit);
-    return this.roots.push(r), r;
+    const r = At(t, s, this.renderKit)
+    return this.roots.push(r), r
   }
   startNavigation() {
-    R(this);
+    R(this)
   }
 }
-const $e = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
-  __proto__: null,
-  App: U
-}, Symbol.toStringTag, { value: "Module" }));
+const $e = /* @__PURE__ */ Object.freeze(
+  /* @__PURE__ */ Object.defineProperty(
+    {
+      __proto__: null,
+      App: U,
+    },
+    Symbol.toStringTag,
+    { value: 'Module' },
+  ),
+)
 class C {
   constructor() {
-    this.lookup = {};
+    this.lookup = {}
   }
   add(t, s, r) {
-    this.ensureArrayFor(t);
+    this.ensureArrayFor(t)
     const n = {
       listener: s,
       index: r,
-      matcher: t
-    };
-    return this.lookup[t].push(n), () => this.remove(n);
+      matcher: t,
+    }
+    return this.lookup[t].push(n), () => this.remove(n)
   }
   remove(t) {
-    this.lookup[t.matcher] && (this.lookup[t.matcher] = this.lookup[t.matcher].reduce((s, r) => (r !== t && s.push(r), s), []));
+    this.lookup[t.matcher] &&
+      (this.lookup[t.matcher] = this.lookup[t.matcher].reduce(
+        (s, r) => (r !== t && s.push(r), s),
+        [],
+      ))
   }
   matches(t) {
-    return this.lookup[t] || [];
+    return this.lookup[t] || []
   }
   ensureArrayFor(t) {
-    this.lookup[t] || (this.lookup[t] = []);
+    this.lookup[t] || (this.lookup[t] = [])
   }
 }
 class I {
   constructor() {
-    this.lookup = [];
+    this.lookup = []
   }
   add(t, s, r) {
     const n = {
       listener: s,
       index: r,
-      matcher: t
-    };
-    return this.lookup.push(n), () => this.remove(n);
+      matcher: t,
+    }
+    return this.lookup.push(n), () => this.remove(n)
   }
   remove(t) {
-    this.lookup = this.lookup.reduce((s, r) => (r !== t && s.push(r), s), []);
+    this.lookup = this.lookup.reduce((s, r) => (r !== t && s.push(r), s), [])
   }
   matches(t) {
-    return this.lookup.filter(
-      (s) => s.matcher.test(t)
-    );
+    return this.lookup.filter((s) => s.matcher.test(t))
   }
 }
 class _t {
-  constructor({
-    publish: t,
-    event: s,
-    payload: r,
-    timer: n
-  }) {
-    this.setNewTimeout = () => {
-      this.stopped || setTimeout(() => {
-        this.publishEvent(), this.setNewTimeout();
-      }, this.calculateNextTime());
-    }, this.calculateNextTime = () => this.timer({
-      timeDiff: this.diff(),
-      callCount: this.callCount,
-      stop: this.stop
-    }), this.publish = t, this.event = s, this.payload = r || null, this.stop = this.stopTimeout.bind(this), this.stopped = !1, this.timer = n, this.startedAt = (/* @__PURE__ */ new Date()).getTime(), this.callCount = 0;
+  constructor({ publish: t, event: s, payload: r, timer: n }) {
+    ;(this.setNewTimeout = () => {
+      this.stopped ||
+        setTimeout(() => {
+          this.publishEvent(), this.setNewTimeout()
+        }, this.calculateNextTime())
+    }),
+      (this.calculateNextTime = () =>
+        this.timer({
+          timeDiff: this.diff(),
+          callCount: this.callCount,
+          stop: this.stop,
+        })),
+      (this.publish = t),
+      (this.event = s),
+      (this.payload = r || null),
+      (this.stop = this.stopTimeout.bind(this)),
+      (this.stopped = !1),
+      (this.timer = n),
+      (this.startedAt = /* @__PURE__ */ new Date().getTime()),
+      (this.callCount = 0)
   }
   start() {
-    this.setNewTimeout();
+    this.setNewTimeout()
   }
   diff() {
-    return (/* @__PURE__ */ new Date()).getTime() - this.startedAt;
+    return /* @__PURE__ */ new Date().getTime() - this.startedAt
   }
   stopTimeout() {
-    this.stopped = !0, this.timeoutId && clearTimeout(this.timeoutId);
+    ;(this.stopped = !0), this.timeoutId && clearTimeout(this.timeoutId)
   }
   publishEvent() {
-    this.stopped || (this.callCount += 1, this.publish(this.event, this.payload));
+    this.stopped ||
+      ((this.callCount += 1), this.publish(this.event, this.payload))
   }
 }
 const St = (e) => {
-  const { offset: t, period: s } = e, r = ({ callCount: n }) => t && n == 0 ? t : s;
-  return {
-    event: e.event,
-    publish: e.publish,
-    payload: e.payload,
-    timer: r
-  };
-}, Tt = (e) => {
-  let t;
-  "timer" in e ? t = e : t = St(
-    e
-  );
-  const s = new _t(t);
-  return s.start(), s.stop;
-};
+    const { offset: t, period: s } = e,
+      r = ({ callCount: n }) => (t && n == 0 ? t : s)
+    return {
+      event: e.event,
+      publish: e.publish,
+      payload: e.payload,
+      timer: r,
+    }
+  },
+  Tt = (e) => {
+    let t
+    'timer' in e ? (t = e) : (t = St(e))
+    const s = new _t(t)
+    return s.start(), s.stop
+  }
 class q {
   constructor() {
-    this.exactSubscriptions = new C(), this.fuzzySubscriptions = new I(), this.currentIndex = 0;
+    ;(this.exactSubscriptions = new C()),
+      (this.fuzzySubscriptions = new I()),
+      (this.currentIndex = 0)
   }
   subscribe(t, s) {
-    let r;
-    return typeof t == "string" ? r = this.exactSubscriptions.add(
-      t,
-      s,
-      this.currentIndex
-    ) : r = this.fuzzySubscriptions.add(
-      t,
-      s,
-      this.currentIndex
-    ), this.currentIndex += 1, r;
+    let r
+    return (
+      typeof t == 'string'
+        ? (r = this.exactSubscriptions.add(t, s, this.currentIndex))
+        : (r = this.fuzzySubscriptions.add(t, s, this.currentIndex)),
+      (this.currentIndex += 1),
+      r
+    )
   }
   publish(t, s) {
-    [
+    ;[
       ...this.exactSubscriptions.matches(t),
-      ...this.fuzzySubscriptions.matches(t)
-    ].sort((n, i) => n.index - i.index).forEach((n) => {
-      n.listener(s, this.listenerOptions(t));
-    });
+      ...this.fuzzySubscriptions.matches(t),
+    ]
+      .sort((n, i) => n.index - i.index)
+      .forEach((n) => {
+        n.listener(s, this.listenerOptions(t))
+      })
   }
   addListenerOptions(t) {
-    this.options = t;
+    this.options = t
   }
   listenerOptions(t) {
     return {
       eventName: t,
       ...this.options,
-      publish: this.publish.bind(this)
-    };
+      publish: this.publish.bind(this),
+    }
   }
 }
 const J = () => {
-  const e = new q();
-  return {
-    bus: e,
-    publish: (r, n) => e.publish(r, n),
-    subscribe: (r, n) => e.subscribe(r, n)
-  };
-}, De = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
-  __proto__: null,
-  ExactSubscriptions: C,
-  FuzzySubscriptions: I,
-  JaxsBus: q,
-  createBus: J,
-  publishPeriodically: Tt
-}, Symbol.toStringTag, { value: "Module" })), f = (e) => Array.isArray(e), v = (e) => e !== null && !f(e) && typeof e == "object", jt = (e, t) => e === t, Ot = (e, t) => Object.keys(e).length === Object.keys(t).length, Mt = (e, t) => !(v(e) && v(t)) || !Ot(e, t) ? !1 : Object.keys(e).every((s) => {
-  const r = e[s], n = t[s];
-  return x(r, n);
-}), kt = (e, t) => !(f(e) && f(t)) || e.length !== t.length ? !1 : e.every((s, r) => {
-  const n = t[r];
-  return x(s, n);
-}), x = (e, t) => v(e) ? Mt(e, t) : f(e) ? kt(e, t) : jt(e, t);
+    const e = new q()
+    return {
+      bus: e,
+      publish: (r, n) => e.publish(r, n),
+      subscribe: (r, n) => e.subscribe(r, n),
+    }
+  },
+  De = /* @__PURE__ */ Object.freeze(
+    /* @__PURE__ */ Object.defineProperty(
+      {
+        __proto__: null,
+        ExactSubscriptions: C,
+        FuzzySubscriptions: I,
+        JaxsBus: q,
+        createBus: J,
+        publishPeriodically: Tt,
+      },
+      Symbol.toStringTag,
+      { value: 'Module' },
+    ),
+  ),
+  f = (e) => Array.isArray(e),
+  v = (e) => e !== null && !f(e) && typeof e == 'object',
+  jt = (e, t) => e === t,
+  Ot = (e, t) => Object.keys(e).length === Object.keys(t).length,
+  Mt = (e, t) =>
+    !(v(e) && v(t)) || !Ot(e, t)
+      ? !1
+      : Object.keys(e).every((s) => {
+          const r = e[s],
+            n = t[s]
+          return x(r, n)
+        }),
+  kt = (e, t) =>
+    !(f(e) && f(t)) || e.length !== t.length
+      ? !1
+      : e.every((s, r) => {
+          const n = t[r]
+          return x(s, n)
+        }),
+  x = (e, t) => (v(e) ? Mt(e, t) : f(e) ? kt(e, t) : jt(e, t))
 class g {
   constructor(t) {
-    this.name = t.name, this.parent = t.parent, this._value = t.value, this.initialValue = structuredClone(t.value);
+    ;(this.name = t.name),
+      (this.parent = t.parent),
+      (this._value = structuredClone(t.value)),
+      (this.initialValue = structuredClone(t.value))
   }
   get value() {
-    return this._value;
+    return this._value
   }
   set value(t) {
-    throw new Error("Cannot set value directly. Use an updater!");
+    throw new Error('Cannot set value directly. Use an updater!')
   }
   reset() {
-    this._value = this.initialValue;
+    this._value = structuredClone(this.initialValue)
   }
   update(t) {
-    if (typeof t == "function") {
-      const s = this.getUpdatedValue(t);
-      this.updateValue(s);
-    } else
-      this.updateValue(t);
+    if (typeof t == 'function') {
+      const s = this.getUpdatedValue(t)
+      this.updateValue(s)
+    } else this.updateValue(t)
   }
   updateValue(t) {
-    x(this._value, t) || (this._value = t, this.parent.notify(this.name));
+    x(this._value, t) || ((this._value = t), this.parent.notify(this.name))
   }
   getUpdatedValue(t) {
-    return t(this.value);
+    return t(structuredClone(this.value))
   }
 }
 class A {
   constructor(t) {
-    this.store = t;
+    this.store = t
   }
   update(t) {
-    this.store.update(t);
+    this.store.update(t)
   }
   reset() {
-    this.store.update(this.store.initialValue);
+    this.store.update(this.store.initialValue)
   }
   get value() {
-    return this.store.value;
+    return this.store.value
   }
 }
 class $t extends A {
   updateAttribute(t, s) {
-    const r = { ...this.value };
-    r[t] = s, this.update(r);
+    const r = { ...this.value }
+    ;(r[t] = s), this.update(r)
   }
   updateDynamicAttribute(t, s) {
-    this.isKey(t) && this.isValueType(t, s) && this.updateAttribute(t, s);
+    this.isKey(t) && this.isValueType(t, s) && this.updateAttribute(t, s)
   }
   isKey(t) {
-    return t in this.store.initialValue;
+    return t in this.store.initialValue
   }
   isValueType(t, s) {
-    return typeof this.store.initialValue[t] == typeof s;
+    return typeof this.store.initialValue[t] == typeof s
   }
   resetAttribute(t) {
-    const s = { ...this.value }, r = this.store.initialValue[t];
-    s[t] = r, this.update(s);
+    const s = { ...this.value },
+      r = this.store.initialValue[t]
+    ;(s[t] = r), this.update(s)
   }
 }
-const Dt = (e) => new $t(e);
+const Dt = (e) => new $t(e)
 class Pt extends A {
   push(t) {
-    const s = [...this.value, t];
-    this.update(s);
+    const s = [...this.value, t]
+    this.update(s)
   }
   pop() {
-    const t = [...this.value], s = t.pop();
-    return this.update(t), s;
+    const t = [...this.value],
+      s = t.pop()
+    return this.update(t), s
   }
   unshift(t) {
-    const s = [t, ...this.value];
-    this.update(s);
+    const s = [t, ...this.value]
+    this.update(s)
   }
   shift() {
-    const t = [...this.value], s = t.shift();
-    return this.update(t), s;
+    const t = [...this.value],
+      s = t.shift()
+    return this.update(t), s
   }
   addSorter(t, s) {
     this[t] = () => {
-      this.sortBy(s);
-    };
+      this.sortBy(s)
+    }
   }
   sortBy(t) {
-    const s = [...this.value];
-    s.sort(t), this.update(s);
+    const s = [...this.value]
+    s.sort(t), this.update(s)
   }
   insertAt(t, s) {
-    const r = [...this.value];
-    r.splice(t, 0, s), this.update(r);
+    const r = [...this.value]
+    r.splice(t, 0, s), this.update(r)
   }
   remove(t) {
-    const s = this.value.reduce((r, n) => (n !== t && r.push(n), r), []);
-    this.update(s);
+    const s = this.value.reduce((r, n) => (n !== t && r.push(n), r), [])
+    this.update(s)
   }
   removeBy(t) {
-    const s = this.value.reduce((r, n) => (t(n) || r.push(n), r), []);
-    this.update(s);
+    const s = this.value.reduce((r, n) => (t(n) || r.push(n), r), [])
+    this.update(s)
   }
 }
-const Vt = (e) => new Pt(e);
+const Vt = (e) => new Pt(e)
 class Ft extends A {
   toggle() {
-    const t = !this.value;
-    this.update(t);
+    const t = !this.value
+    this.update(t)
   }
   setTrue() {
-    this.update(!0);
+    this.update(!0)
   }
   setFalse() {
-    this.update(!1);
+    this.update(!1)
   }
 }
-const Lt = (e) => new Ft(e), zt = {
-  object: Dt,
-  list: Vt,
-  boolean: Lt
-}, w = "state";
+const Lt = (e) => new Ft(e),
+  zt = {
+    object: Dt,
+    list: Vt,
+    boolean: Lt,
+  },
+  w = 'state'
 class G {
   constructor(t) {
-    this.publisher = t, this.stores = {}, this.eventNamePrefix = w, this.notifications = /* @__PURE__ */ new Set(), this.inTransaction = !1;
+    ;(this.publisher = t),
+      (this.stores = {}),
+      (this.eventNamePrefix = w),
+      (this.notifications = /* @__PURE__ */ new Set()),
+      (this.inTransaction = !1)
   }
   create(t, s) {
     const r = new g({
       name: t,
       parent: this,
-      value: s
-    });
-    return this.stores[t] = r, r;
+      value: s,
+    })
+    return (this.stores[t] = r), r
   }
   store(t) {
-    return this.stores[t] || new g({
-      name: t,
-      parent: this,
-      value: void 0
-    });
+    return (
+      this.stores[t] ||
+      new g({
+        name: t,
+        parent: this,
+        value: void 0,
+      })
+    )
   }
   get(t) {
-    return this.store(t).value;
+    return this.store(t).value
   }
   getAll(t) {
-    return t.reduce((s, r) => (s[r] = this.get(r), s), {});
+    return t.reduce((s, r) => ((s[r] = this.get(r)), s), {})
   }
   notify(t) {
-    this.inTransaction ? this.notifications.add(t) : this.publish(t);
+    this.inTransaction ? this.notifications.add(t) : this.publish(t)
   }
   update(t, s) {
-    this.store(t).update(s);
+    this.store(t).update(s)
   }
   transaction(t) {
-    this.inTransaction = !0, t(this.stores), this.inTransaction = !1, this.publishAll();
+    ;(this.inTransaction = !0),
+      t(this.stores),
+      (this.inTransaction = !1),
+      this.publishAll()
   }
   publishAll() {
     this.notifications.forEach((t) => {
-      this.publish(t);
-    }), this.notifications.clear();
+      this.publish(t)
+    }),
+      this.notifications.clear()
   }
   publish(t) {
     this.publisher(this.event(t), {
       state: this,
-      store: this.store(t)
-    });
+      store: this.store(t),
+    })
   }
   event(t) {
-    return `${this.eventNamePrefix}:${t}`;
+    return `${this.eventNamePrefix}:${t}`
   }
 }
-const H = (e) => new G(e), Pe = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
-  __proto__: null,
-  State: G,
-  Store: g,
-  createState: H,
-  eventName: w,
-  updaters: zt
-}, Symbol.toStringTag, { value: "Module" }));
+const H = (e) => new G(e),
+  Pe = /* @__PURE__ */ Object.freeze(
+    /* @__PURE__ */ Object.defineProperty(
+      {
+        __proto__: null,
+        State: G,
+        Store: g,
+        createState: H,
+        eventName: w,
+        updaters: zt,
+      },
+      Symbol.toStringTag,
+      { value: 'Module' },
+    ),
+  )
 class Bt {
   constructor(t) {
-    this.setupDomEnvironment(t);
+    this.setupDomEnvironment(t)
   }
   setup() {
-    return this.setupBus(), this.setupState(), this.addBusOptions(), this.setRenderKit(), new U({
-      window: this.window,
-      document: this.document,
-      publish: this.publish,
-      subscribe: this.subscribe,
-      bus: this.bus,
-      state: this.state,
-      renderKit: this.renderKit
-    });
+    return (
+      this.setupBus(),
+      this.setupState(),
+      this.addBusOptions(),
+      this.setRenderKit(),
+      new U({
+        window: this.window,
+        document: this.document,
+        publish: this.publish,
+        subscribe: this.subscribe,
+        bus: this.bus,
+        state: this.state,
+        renderKit: this.renderKit,
+      })
+    )
   }
   setupDomEnvironment(t) {
-    t.window ? (this.window = t.window, this.document = this.window.document) : t.document ? (this.window = t.document.defaultView, this.document = t.document) : (this.window = window, this.document = document);
+    t.window
+      ? ((this.window = t.window), (this.document = this.window.document))
+      : t.document
+        ? ((this.window = t.document.defaultView), (this.document = t.document))
+        : ((this.window = window), (this.document = document))
   }
   setupBus() {
-    const { publish: t, subscribe: s, bus: r } = J();
-    this.publish = t, this.subscribe = s, this.bus = r;
+    const { publish: t, subscribe: s, bus: r } = J()
+    ;(this.publish = t), (this.subscribe = s), (this.bus = r)
   }
   setupState() {
-    this.state = H(this.publish);
+    this.state = H(this.publish)
   }
   addBusOptions() {
     this.bus.addListenerOptions({
       state: this.state,
       document: this.document,
-      window: this.window
-    });
+      window: this.window,
+    })
   }
   setRenderKit() {
     this.renderKit = {
@@ -645,388 +807,534 @@ class Bt {
       subscribe: this.subscribe,
       state: this.state,
       document: this.document,
-      window: this.window
-    };
+      window: this.window,
+    }
   }
 }
 const Ve = (e = {}) => {
-  const s = new Bt(e).setup();
-  return s.startNavigation(), s;
-};
-var o = /* @__PURE__ */ ((e) => (e[e.removeNode = 0] = "removeNode", e[e.insertNode = 1] = "insertNode", e[e.replaceNode = 2] = "replaceNode", e[e.removeAttribute = 3] = "removeAttribute", e[e.addAttribute = 4] = "addAttribute", e[e.updateAttribute = 5] = "updateAttribute", e[e.removeEvent = 6] = "removeEvent", e[e.addEvent = 7] = "addEvent", e[e.updateEvent = 8] = "updateEvent", e[e.changeValue = 9] = "changeValue", e[e.changeText = 10] = "changeText", e))(o || {});
-const Fe = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
-  __proto__: null,
-  ChangeInstructionTypes: o
-}, Symbol.toStringTag, { value: "Module" })), Kt = (e, t) => ({
-  source: e,
-  target: t,
-  type: o.changeText,
-  data: {}
-}), Rt = (e, t) => ({
-  source: e,
-  target: t,
-  type: o.replaceNode,
-  data: {}
-}), Ut = (e, t, s) => ({
-  source: e,
-  target: t,
-  data: s,
-  type: o.removeAttribute
-}), Ct = (e, t, s) => ({
-  source: e,
-  target: t,
-  data: s,
-  type: o.addAttribute
-}), It = (e, t, s) => ({
-  source: e,
-  target: t,
-  data: s,
-  type: o.updateAttribute
-}), qt = (e, t, s) => ({
-  source: e,
-  target: t,
-  data: s,
-  type: o.removeEvent
-}), Jt = (e, t, s) => ({
-  source: e,
-  target: t,
-  data: s,
-  type: o.addEvent
-}), Gt = (e, t, s) => ({
-  source: e,
-  target: t,
-  data: s,
-  type: o.updateEvent
-}), N = (e) => ({
-  source: e,
-  target: e,
-  // for type crap only
-  type: o.removeNode,
-  data: {}
-}), b = (e, t) => ({
-  target: e,
-  source: e,
-  // for type crap only
-  type: o.insertNode,
-  data: t
-}), Ht = (e, t, s) => ({
-  source: e,
-  target: t,
-  type: o.changeValue,
-  data: s
-}), Qt = (e, t) => e.type > t.type ? 1 : e.type < t.type ? -1 : 0, _ = { index: -1 };
+  const s = new Bt(e).setup()
+  return s.startNavigation(), s
+}
+var o = /* @__PURE__ */ ((e) => (
+  (e[(e.removeNode = 0)] = 'removeNode'),
+  (e[(e.insertNode = 1)] = 'insertNode'),
+  (e[(e.replaceNode = 2)] = 'replaceNode'),
+  (e[(e.removeAttribute = 3)] = 'removeAttribute'),
+  (e[(e.addAttribute = 4)] = 'addAttribute'),
+  (e[(e.updateAttribute = 5)] = 'updateAttribute'),
+  (e[(e.removeEvent = 6)] = 'removeEvent'),
+  (e[(e.addEvent = 7)] = 'addEvent'),
+  (e[(e.updateEvent = 8)] = 'updateEvent'),
+  (e[(e.changeValue = 9)] = 'changeValue'),
+  (e[(e.changeText = 10)] = 'changeText'),
+  e
+))(o || {})
+const Fe = /* @__PURE__ */ Object.freeze(
+    /* @__PURE__ */ Object.defineProperty(
+      {
+        __proto__: null,
+        ChangeInstructionTypes: o,
+      },
+      Symbol.toStringTag,
+      { value: 'Module' },
+    ),
+  ),
+  Kt = (e, t) => ({
+    source: e,
+    target: t,
+    type: o.changeText,
+    data: {},
+  }),
+  Rt = (e, t) => ({
+    source: e,
+    target: t,
+    type: o.replaceNode,
+    data: {},
+  }),
+  Ut = (e, t, s) => ({
+    source: e,
+    target: t,
+    data: s,
+    type: o.removeAttribute,
+  }),
+  Ct = (e, t, s) => ({
+    source: e,
+    target: t,
+    data: s,
+    type: o.addAttribute,
+  }),
+  It = (e, t, s) => ({
+    source: e,
+    target: t,
+    data: s,
+    type: o.updateAttribute,
+  }),
+  qt = (e, t, s) => ({
+    source: e,
+    target: t,
+    data: s,
+    type: o.removeEvent,
+  }),
+  Jt = (e, t, s) => ({
+    source: e,
+    target: t,
+    data: s,
+    type: o.addEvent,
+  }),
+  Gt = (e, t, s) => ({
+    source: e,
+    target: t,
+    data: s,
+    type: o.updateEvent,
+  }),
+  N = (e) => ({
+    source: e,
+    target: e,
+    // for type crap only
+    type: o.removeNode,
+    data: {},
+  }),
+  b = (e, t) => ({
+    target: e,
+    source: e,
+    // for type crap only
+    type: o.insertNode,
+    data: t,
+  }),
+  Ht = (e, t, s) => ({
+    source: e,
+    target: t,
+    type: o.changeValue,
+    data: s,
+  }),
+  Qt = (e, t) => (e.type > t.type ? 1 : e.type < t.type ? -1 : 0),
+  _ = { index: -1 }
 class Wt {
   constructor() {
-    this.map = {};
+    this.map = {}
   }
   populate(t) {
     t.forEach((s, r) => {
-      const n = s.__jsx;
-      n && (this.map[n] = this.map[n] || [], this.map[n].push({
-        element: s,
-        index: r
-      }));
-    });
+      const n = s.__jsx
+      n &&
+        ((this.map[n] = this.map[n] || []),
+        this.map[n].push({
+          element: s,
+          index: r,
+        }))
+    })
   }
   pullMatch(t) {
-    const s = t && t.__jsx;
-    return !s || !(this.map[s] && this.map[s].length) ? _ : this.map[s].shift();
+    const s = t && t.__jsx
+    return !s || !(this.map[s] && this.map[s].length) ? _ : this.map[s].shift()
   }
   clear(t) {
-    const s = t && t.__jsx;
-    if (!(s && this.map[s] && this.map[s].length)) return;
-    const r = this.map[s];
-    this.map[s] = r.reduce((n, i) => (i.element !== t && n.push(i), n), []);
+    const s = t && t.__jsx
+    if (!(s && this.map[s] && this.map[s].length)) return
+    const r = this.map[s]
+    this.map[s] = r.reduce((n, i) => (i.element !== t && n.push(i), n), [])
   }
   check(t) {
-    const s = t && t.__jsx;
-    return s && this.map[s] ? this.map[s].length > 0 : !1;
+    const s = t && t.__jsx
+    return s && this.map[s] ? this.map[s].length > 0 : !1
   }
   remaining() {
-    return Object.values(this.map).flat();
+    return Object.values(this.map).flat()
   }
 }
 const S = (e) => {
-  const t = new Wt();
-  return t.populate(e), t;
-}, Q = (e, t, s = !1) => {
-  const r = [], n = e.attributes, i = n.length, a = t.attributes, l = a.length;
-  let u, d, c;
-  for (u = 0; u < i; u++) {
-    c = null;
-    const h = n.item(u);
-    if (h) {
-      for (d = 0; d < l; d++) {
-        const p = a.item(d);
-        if (p && h.name == p.name) {
-          c = p;
-          break;
+    const t = new Wt()
+    return t.populate(e), t
+  },
+  Q = (e, t, s = !1) => {
+    const r = [],
+      n = e.attributes,
+      i = n.length,
+      a = t.attributes,
+      l = a.length
+    let u, d, c
+    for (u = 0; u < i; u++) {
+      c = null
+      const h = n.item(u)
+      if (h) {
+        for (d = 0; d < l; d++) {
+          const p = a.item(d)
+          if (p && h.name == p.name) {
+            c = p
+            break
+          }
         }
+        c
+          ? h.value !== c.value &&
+            r.push(
+              It(e, t, {
+                name: h.name,
+                value: c.value,
+                isSvg: s,
+              }),
+            )
+          : r.push(Ut(e, t, { name: h.name, isSvg: s }))
       }
-      c ? h.value !== c.value && r.push(
-        It(e, t, {
-          name: h.name,
-          value: c.value,
-          isSvg: s
-        })
-      ) : r.push(
-        Ut(e, t, { name: h.name, isSvg: s })
-      );
     }
-  }
-  for (u = 0; u < l; u++) {
-    c = null;
-    const h = a.item(u);
-    if (h) {
-      for (d = 0; d < i; d++) {
-        const p = n.item(d);
-        if (p && p.name == h.name) {
-          c = p;
-          break;
+    for (u = 0; u < l; u++) {
+      c = null
+      const h = a.item(u)
+      if (h) {
+        for (d = 0; d < i; d++) {
+          const p = n.item(d)
+          if (p && p.name == h.name) {
+            c = p
+            break
+          }
         }
+        c ||
+          r.push(
+            Ct(e, t, {
+              name: h.name,
+              value: h.value,
+              isSvg: s,
+            }),
+          )
       }
-      c || r.push(
-        Ct(e, t, {
-          name: h.name,
-          value: h.value,
-          isSvg: s
-        })
-      );
     }
+    return r
+  },
+  Xt = (e, t) => {
+    const s = [],
+      r = e.eventMaps,
+      n = t.eventMaps,
+      i = Object.keys(r),
+      a = Object.keys(n)
+    return (
+      i.forEach((l) => {
+        const u = r[l],
+          d = n[l]
+        d
+          ? d.busEvent !== u.busEvent &&
+            s.push(
+              Gt(e, t, {
+                name: l,
+                targetValue: d.listener,
+                sourceValue: u.listener,
+              }),
+            )
+          : s.push(
+              qt(e, t, {
+                name: u.domEvent,
+                value: u.listener,
+              }),
+            )
+      }),
+      a.forEach((l) => {
+        const u = r[l],
+          d = n[l]
+        u ||
+          s.push(
+            Jt(e, t, {
+              name: d.domEvent,
+              value: d.listener,
+            }),
+          )
+      }),
+      s
+    )
+  },
+  Yt = (e) => e.tagName !== 'INPUT',
+  Zt = (e, t) => e.value === t.value,
+  te = (e, t) => {
+    if (Yt(e) || Zt(e, t)) return []
+    const s = e,
+      r = t
+    return [Ht(s, r, { name: 'value', value: r.value })]
+  },
+  ee = (e, t) => {
+    const s = Q(e, t),
+      r = Xt(e, t),
+      n = te(e, t)
+    return s.concat(r).concat(n)
+  },
+  se = (e, t) => Q(e, t, !0),
+  re = (e, t) => (e.textContent !== t.textContent ? [Kt(e, t)] : []),
+  ne = (e, t, s) => {
+    let r = []
+    if (e.nodeType === 1 && ot(e)) {
+      const n = e,
+        i = t,
+        a = se(n, i),
+        l = s(n.childNodes, i.childNodes, n)
+      r = a.concat(l)
+    } else if (e.nodeType === 1) {
+      const n = e,
+        i = t,
+        a = ee(n, i),
+        l = s(n.childNodes, i.childNodes, n)
+      r = a.concat(l)
+    } else e.nodeType === 3 && (r = re(e, t))
+    return r
+  },
+  W = (e, t, s) => {
+    const r = [],
+      n = ie(e, t),
+      i = S(e),
+      a = S(t),
+      l = []
+    let u = 0
+    for (; u < n; u++) {
+      const c = e[u],
+        h = t[u]
+      if (h && a.check(h)) {
+        const p = i.pullMatch(h)
+        a.clear(h),
+          p.element
+            ? (p.index !== u &&
+                r.push(
+                  b(p.element, {
+                    parent: s,
+                    index: u,
+                  }),
+                ),
+              l.push({
+                source: p.element,
+                target: h,
+              }))
+            : c
+              ? a.check(c)
+                ? r.push(b(h, { parent: s, index: u }))
+                : (i.clear(c), r.push(Rt(c, h)))
+              : r.push(b(h, { parent: s, index: u }))
+      } else c && i.pullMatch(c).element && r.push(N(c))
+    }
+    i.remaining().forEach(({ element: c }) => {
+      r.push(N(c))
+    })
+    const d = l.reduce(
+      (c, { source: h, target: p }) => c.concat(ne(h, p, W)),
+      [],
+    )
+    return r.concat(d).sort(Qt)
+  },
+  ie = (e, t) => {
+    const s = e.length,
+      r = t.length
+    return s > r ? s : r
+  },
+  oe = (e, t, s) => {
+    const r = W(e, t, s)
+    return (
+      r.forEach((n) => {
+        ue(n)
+      }),
+      r
+    )
+  },
+  ue = (e) => {
+    ;(ye[e.type] || ae)(e)
+  },
+  ae = (e) => {},
+  ce = (e) => {
+    const { source: t, target: s } = e
+    t.nodeValue = s.textContent
+  },
+  le = (e) => {
+    const { source: t } = e
+    t.remove()
+  },
+  he = (e) => {
+    const { target: t, data: s } = e,
+      { parent: r, index: n } = s,
+      i = r.childNodes[n]
+    i ? i && i !== t && r.insertBefore(t, i) : r.appendChild(t)
+  },
+  de = (e) => {
+    const { source: t, target: s } = e
+    t.replaceWith(s)
+  },
+  pe = (e) => {
+    const { source: t, data: s } = e,
+      { name: r, isSvg: n } = s
+    n ? t.removeAttributeNS(null, r) : t.removeAttribute(r)
+  },
+  X = (e) => {
+    const { source: t, data: s } = e,
+      { name: r, value: n, isSvg: i } = s
+    i ? t.setAttributeNS(null, r, n) : t.setAttribute(r, n)
+  },
+  me = (e) => {
+    X(e)
+  },
+  fe = (e) => {
+    const t = e.data,
+      s = e.source,
+      { name: r, value: n } = t
+    s.removeEventListener(r, n)
+  },
+  be = (e) => {
+    const t = e.data,
+      s = e.source,
+      { name: r, value: n } = t
+    s.addEventListener(r, n)
+  },
+  ve = (e) => {
+    const t = e.data,
+      s = e.source,
+      { name: r, sourceValue: n, targetValue: i } = t
+    s.removeEventListener(r, n), s.addEventListener(r, i)
+  },
+  ge = (e) => {
+    const t = e.data,
+      s = e.source,
+      { value: r } = t
+    s.value = r
+  },
+  ye = {
+    [o.changeText]: ce,
+    [o.removeNode]: le,
+    [o.insertNode]: he,
+    [o.replaceNode]: de,
+    [o.removeAttribute]: pe,
+    [o.addAttribute]: X,
+    [o.updateAttribute]: me,
+    [o.removeEvent]: fe,
+    [o.addEvent]: be,
+    [o.updateEvent]: ve,
+    [o.changeValue]: ge,
+  },
+  Ee = (e, t, s) => {
+    const r = [...t]
+    return (
+      e.forEach((n) => {
+        xe(n, r, s)
+      }),
+      r
+    )
+  },
+  xe = (e, t, s) => {
+    const r = _e[e.type]
+    r && r(e, t, s)
+  },
+  Ae = (e, t) => {
+    const { source: s } = e,
+      r = t.indexOf(s)
+    r >= 0 && t.splice(r, 1)
+  },
+  we = (e, t, s) => {
+    const { target: r } = e,
+      n = e.data,
+      { index: i, parent: a } = n
+    s === a && t.splice(i, 0, r)
+  },
+  Ne = (e, t) => {
+    const { target: s, source: r } = e,
+      n = t.indexOf(r)
+    n >= 0 && (t[n] = s)
+  },
+  _e = {
+    [o.removeNode]: Ae,
+    [o.insertNode]: we,
+    [o.replaceNode]: Ne,
   }
-  return r;
-}, Xt = (e, t) => {
-  const s = [], r = e.eventMaps, n = t.eventMaps, i = Object.keys(r), a = Object.keys(n);
-  return i.forEach((l) => {
-    const u = r[l], d = n[l];
-    d ? d.busEvent !== u.busEvent && s.push(
-      Gt(e, t, {
-        name: l,
-        targetValue: d.listener,
-        sourceValue: u.listener
-      })
-    ) : s.push(
-      qt(e, t, {
-        name: u.domEvent,
-        value: u.listener
-      })
-    );
-  }), a.forEach((l) => {
-    const u = r[l], d = n[l];
-    u || s.push(
-      Jt(e, t, {
-        name: d.domEvent,
-        value: d.listener
-      })
-    );
-  }), s;
-}, Yt = (e) => e.tagName !== "INPUT", Zt = (e, t) => e.value === t.value, te = (e, t) => {
-  if (Yt(e) || Zt(e, t))
-    return [];
-  const s = e, r = t;
-  return [Ht(s, r, { name: "value", value: r.value })];
-}, ee = (e, t) => {
-  const s = Q(e, t), r = Xt(e, t), n = te(e, t);
-  return s.concat(r).concat(n);
-}, se = (e, t) => Q(e, t, !0), re = (e, t) => e.textContent !== t.textContent ? [Kt(e, t)] : [], ne = (e, t, s) => {
-  let r = [];
-  if (e.nodeType === 1 && ot(e)) {
-    const n = e, i = t, a = se(n, i), l = s(
-      n.childNodes,
-      i.childNodes,
-      n
-    );
-    r = a.concat(l);
-  } else if (e.nodeType === 1) {
-    const n = e, i = t, a = ee(n, i), l = s(
-      n.childNodes,
-      i.childNodes,
-      n
-    );
-    r = a.concat(l);
-  } else e.nodeType === 3 && (r = re(e, t));
-  return r;
-}, W = (e, t, s) => {
-  const r = [], n = ie(e, t), i = S(e), a = S(t), l = [];
-  let u = 0;
-  for (; u < n; u++) {
-    const c = e[u], h = t[u];
-    if (h && a.check(h)) {
-      const p = i.pullMatch(h);
-      a.clear(h), p.element ? (p.index !== u && r.push(
-        b(p.element, {
-          parent: s,
-          index: u
-        })
-      ), l.push({
-        source: p.element,
-        target: h
-      })) : c ? a.check(c) ? r.push(
-        b(h, { parent: s, index: u })
-      ) : (i.clear(c), r.push(
-        Rt(c, h)
-      )) : r.push(
-        b(h, { parent: s, index: u })
-      );
-    } else c && i.pullMatch(c).element && r.push(N(c));
-  }
-  i.remaining().forEach(({ element: c }) => {
-    r.push(N(c));
-  });
-  const d = l.reduce(
-    (c, { source: h, target: p }) => c.concat(
-      ne(h, p, W)
-    ),
-    []
-  );
-  return r.concat(d).sort(Qt);
-}, ie = (e, t) => {
-  const s = e.length, r = t.length;
-  return s > r ? s : r;
-}, oe = (e, t, s) => {
-  const r = W(e, t, s);
-  return r.forEach((n) => {
-    ue(n);
-  }), r;
-}, ue = (e) => {
-  (ye[e.type] || ae)(e);
-}, ae = (e) => {
-}, ce = (e) => {
-  const { source: t, target: s } = e;
-  t.nodeValue = s.textContent;
-}, le = (e) => {
-  const { source: t } = e;
-  t.remove();
-}, he = (e) => {
-  const { target: t, data: s } = e, { parent: r, index: n } = s, i = r.childNodes[n];
-  i ? i && i !== t && r.insertBefore(t, i) : r.appendChild(t);
-}, de = (e) => {
-  const { source: t, target: s } = e;
-  t.replaceWith(s);
-}, pe = (e) => {
-  const { source: t, data: s } = e, { name: r, isSvg: n } = s;
-  n ? t.removeAttributeNS(null, r) : t.removeAttribute(r);
-}, X = (e) => {
-  const { source: t, data: s } = e, { name: r, value: n, isSvg: i } = s;
-  i ? t.setAttributeNS(null, r, n) : t.setAttribute(r, n);
-}, me = (e) => {
-  X(e);
-}, fe = (e) => {
-  const t = e.data, s = e.source, { name: r, value: n } = t;
-  s.removeEventListener(r, n);
-}, be = (e) => {
-  const t = e.data, s = e.source, { name: r, value: n } = t;
-  s.addEventListener(r, n);
-}, ve = (e) => {
-  const t = e.data, s = e.source, { name: r, sourceValue: n, targetValue: i } = t;
-  s.removeEventListener(r, n), s.addEventListener(r, i);
-}, ge = (e) => {
-  const t = e.data, s = e.source, { value: r } = t;
-  s.value = r;
-}, ye = {
-  [o.changeText]: ce,
-  [o.removeNode]: le,
-  [o.insertNode]: he,
-  [o.replaceNode]: de,
-  [o.removeAttribute]: pe,
-  [o.addAttribute]: X,
-  [o.updateAttribute]: me,
-  [o.removeEvent]: fe,
-  [o.addEvent]: be,
-  [o.updateEvent]: ve,
-  [o.changeValue]: ge
-}, Ee = (e, t, s) => {
-  const r = [...t];
-  return e.forEach((n) => {
-    xe(n, r, s);
-  }), r;
-}, xe = (e, t, s) => {
-  const r = _e[e.type];
-  r && r(e, t, s);
-}, Ae = (e, t) => {
-  const { source: s } = e, r = t.indexOf(s);
-  r >= 0 && t.splice(r, 1);
-}, we = (e, t, s) => {
-  const { target: r } = e, n = e.data, { index: i, parent: a } = n;
-  s === a && t.splice(i, 0, r);
-}, Ne = (e, t) => {
-  const { target: s, source: r } = e, n = t.indexOf(r);
-  n >= 0 && (t[n] = s);
-}, _e = {
-  [o.removeNode]: Ae,
-  [o.insertNode]: we,
-  [o.replaceNode]: Ne
-};
 class Se {
   constructor({ Template: t, subscriptions: s, attributes: r, viewModel: n }) {
-    this.Template = t, this.viewModel = n, this.attributes = r, this.subscriptions = s, this.dom = [], this.parentElement = null;
+    ;(this.Template = t),
+      (this.viewModel = n),
+      (this.attributes = r),
+      (this.subscriptions = s),
+      (this.dom = []),
+      (this.parentElement = null)
   }
   render(t) {
-    return this.parentElement = t.parent, this.renderKit = t, this.subscribeForRerender(), this.dom = this.generateDom(t), this.dom;
+    return (
+      (this.parentElement = t.parent),
+      (this.renderKit = t),
+      this.subscribeForRerender(),
+      (this.dom = this.generateDom(t)),
+      this.dom
+    )
   }
   generateDom(t) {
     const s = {
-      ...this.attributes,
-      ...this.viewModel(
-        t.state.getAll(this.subscriptions)
-      )
-    }, r = this.Template(s);
-    return r ? r.render(t) : [];
+        ...this.attributes,
+        ...this.viewModel(t.state.getAll(this.subscriptions)),
+      },
+      r = this.Template(s)
+    return r ? r.render(t) : []
   }
   rerender() {
     if (!this.parentElement && this.dom[0]) {
-      const r = this.dom[0].parentElement;
-      this.parentElement = r;
+      const r = this.dom[0].parentElement
+      this.parentElement = r
     }
-    const t = this.generateDom(this.renderKit), s = oe(
-      this.dom,
-      t,
-      this.parentElement
-    );
-    this.dom = Ee(
-      s,
-      this.dom,
-      this.parentElement
-    );
+    const t = this.generateDom(this.renderKit),
+      s = oe(this.dom, t, this.parentElement)
+    this.dom = Ee(s, this.dom, this.parentElement)
   }
   subscribeForRerender() {
-    const { subscribe: t } = this.renderKit;
+    const { subscribe: t } = this.renderKit
     this.subscriptions.forEach((s) => {
-      t(this.eventName(s), () => this.rerender());
-    });
+      t(this.eventName(s), () => this.rerender())
+    })
   }
   eventName(t) {
-    return `${w}:${t}`;
+    return `${w}:${t}`
   }
 }
-const Te = (e) => e, je = ({
-  Template: e,
-  viewModel: t,
-  subscriptions: s
-}) => (s = s || [], t = t || Te, (r) => new Se({ Template: e, viewModel: t, subscriptions: s, attributes: r })), Le = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
-  __proto__: null,
-  createRouteState: D,
-  events: wt,
-  extractQueryParams: F,
-  findHref: P,
-  navigate: E,
-  onLinkClick: V,
-  onLocationChange: L,
-  start: Nt
-}, Symbol.toStringTag, { value: "Module" })), Oe = (e) => ({ path: t }) => t === e, Me = () => !0, Y = (e) => ({ route: t }) => {
-  const s = e.find((r) => r.match(t));
-  return s && s.Partial;
-}, ze = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
-  __proto__: null,
-  buildRouter: Y,
-  catchAll: Me,
-  exactPathMatch: Oe
-}, Symbol.toStringTag, { value: "Module" })), ke = () => ({
-  render: (e, t) => []
-}), Be = (e) => {
-  const t = Y(e);
-  return je({ Template: ({ route: r }) => (t({ route: r }) || ke)(), subscriptions: ["route"] });
-};
+const Te = (e) => e,
+  je = ({ Template: e, viewModel: t, subscriptions: s }) => (
+    (s = s || []),
+    (t = t || Te),
+    (r) =>
+      new Se({ Template: e, viewModel: t, subscriptions: s, attributes: r })
+  ),
+  Le = /* @__PURE__ */ Object.freeze(
+    /* @__PURE__ */ Object.defineProperty(
+      {
+        __proto__: null,
+        createRouteState: D,
+        events: wt,
+        extractQueryParams: F,
+        findHref: P,
+        navigate: E,
+        onLinkClick: V,
+        onLocationChange: L,
+        start: Nt,
+      },
+      Symbol.toStringTag,
+      { value: 'Module' },
+    ),
+  ),
+  Oe =
+    (e) =>
+    ({ path: t }) =>
+      t === e,
+  Me = () => !0,
+  Y =
+    (e) =>
+    ({ route: t }) => {
+      const s = e.find((r) => r.match(t))
+      return s && s.Partial
+    },
+  ze = /* @__PURE__ */ Object.freeze(
+    /* @__PURE__ */ Object.defineProperty(
+      {
+        __proto__: null,
+        buildRouter: Y,
+        catchAll: Me,
+        exactPathMatch: Oe,
+      },
+      Symbol.toStringTag,
+      { value: 'Module' },
+    ),
+  ),
+  ke = () => ({
+    render: (e, t) => [],
+  }),
+  Be = (e) => {
+    const t = Y(e)
+    return je({
+      Template: ({ route: r }) => (t({ route: r }) || ke)(),
+      subscriptions: ['route'],
+    })
+  }
 export {
   Fe as JaxsTypes,
   $e as appBuilding,
@@ -1037,5 +1345,5 @@ export {
   Le as navigation,
   Be as routedView,
   ze as routing,
-  Pe as state
-};
+  Pe as state,
+}

--- a/dist/jaxs.umd.cjs
+++ b/dist/jaxs.umd.cjs
@@ -1,1 +1,1220 @@
-(function(p,f){typeof exports=="object"&&typeof module<"u"?f(exports):typeof define=="function"&&define.amd?define(["exports"],f):(p=typeof globalThis<"u"?globalThis:p||self,f(p.jaxs={}))})(this,function(p){"use strict";const f=(e,t)=>t.createElement(e),nt=(e,t)=>{for(const s in t){if(s==="__self")continue;const n=t[s].toString();if(s==="value"){const r=e;r.value!==n&&(r.value=n)}else e.setAttribute(s,n)}},rt=(e,t,s)=>{const n={};for(const r in t){const i=t[r],a=l=>s(i,l);e.addEventListener(r,a),n[r]={domEvent:r,busEvent:i,listener:a}}e.eventMaps=n},it=(e,t,s,n)=>{const r=f(e,n.document);return nt(r,t),rt(r,s,n.publish),r},g="http://www.w3.org/2000/svg",ot={animate:!0,animateMotion:!0,animateTransform:!0,circle:!0,clipPath:!0,defs:!0,desc:!0,ellipse:!0,feBlend:!0,feColorMatrix:!0,feComponentTransfer:!0,feComposite:!0,feConvolveMatrix:!0,feDiffuseLighting:!0,feDisplacementMap:!0,feDistantLight:!0,feDropShadow:!0,feFlood:!0,feFuncA:!0,feFuncB:!0,feFuncG:!0,feFuncR:!0,feGaussianBlur:!0,feImage:!0,feMerge:!0,feMergeNode:!0,feMorphology:!0,feOffset:!0,fePointLight:!0,feSpecularLighting:!0,feSpotLight:!0,feTile:!0,feTurbulence:!0,filter:!0,foreignObject:!0,g:!0,image:!0,line:!0,linearGradient:!0,marker:!0,mask:!0,metadata:!0,mpath:!0,path:!0,pattern:!0,polygon:!0,polyline:!0,radialGradient:!0,rect:!0,script:!0,set:!0,stop:!0,style:!0,svg:!0,switch:!0,symbol:!0,text:!0,textPath:!0,title:!0,tspan:!0,use:!0,view:!0},ut=(e,t)=>!!(ot[e]||e==="a"&&t===g),at=(e,t,s)=>{const n=s.createElementNS(g,e);for(const r in t)r==="__self"||r==="xmlns"||n.setAttributeNS(null,r,t[r].toString());return n},ct=e=>e.namespaceURI===g,lt=(e,t)=>t.createTextNode(e);class ht{constructor(t){this.value=t.toString()}render(t){const s=lt(this.value,t.document);return s.__jsx="TextNode",[s]}}const dt=e=>typeof e=="string"||typeof e=="number",pt=e=>new ht(e),mt=e=>dt(e)?pt(e):e,ft=e=>bt(e).map(mt).flat(),bt=e=>Array.isArray(e)?e.flat():e?[e]:[],S=(e,t={})=>e||t.children||[],vt=(e,t="")=>{const s={},n={};for(const r in e){const i=e[r];if(r.match(/^on.+/i)){const a=r.slice(2).toLowerCase();n[a]=i?i.toString():""}else{if(i===!1)continue;r==="__source"?s.__source=e.__source:s[r]=gt(r,i,t)}}return{attributes:s,events:n}},gt=(e,t,s="")=>t==null?s:t.toString(),yt=(e,t)=>{const s=e||{},n=S(t,s);return s.children=s.children||n,s},T=(e,t,s,n=[])=>e.reduce(Et(t,s),n).flat(),Et=(e,t)=>(s,n)=>n?Array.isArray(n)?T(n,e,t,s):(n.render(e,t).forEach(r=>s.push(r)),s):s;class j{constructor(t){this.collection=ft(t)}render(t,s){this.parentElement=s;const n=this.generateDom(t);return this.attachToParent(n),n}generateDom(t){return T(this.collection,t,this.parentElement)}attachToParent(t){if(this.parentElement===void 0)return;const s=this.parentElement;t.forEach(n=>s.appendChild(n))}}class At{constructor(t,s){this.type=t,this.attributes=s}generate(){return this.attributes.key||this.sourceKey()||this.createKeyFromAttributes()}sourceKey(){if(this.attributes.__source){const{fileName:t,lineNumber:s,columnNumber:n}=this.attributes.__source;return`${t}:${s}:${n}`}}createKeyFromAttributes(){const t=this.attributes.id?`#${this.attributes.id}`:"",s=this.attributes.type?`[type=${this.attributes.type}]`:"",n=this.attributes.name?`[name=${this.attributes.name}]`:"";return`${this.type}${t}${s}${n}`}}class xt{constructor(t,s,n=[]){this.type=t;const{events:r,attributes:i}=vt(s);this.events=r,this.attributes=i,this.isSvg=ut(this.type,this.attributes.xmlns),this.children=new j(n)}render(t){const s=this.generateDom(t);return s?(this.children.render(t,s),[s]):[]}generateDom(t){return this.isSvg?this.generateSvgDom(t):this.generateHtmlDom(t)}generateHtmlDom(t){const s=it(this.type,this.attributes,this.events,t);return s.__jsx=this.jsxKey(),s}generateSvgDom(t){const s=at(this.type,this.attributes,t.document);return s.__jsx=this.jsxKey(),s}jsxKey(){return new At(this.type,this.attributes).generate()}}const O=(e,t,...s)=>typeof e=="string"?new xt(e,t,s):e(yt(t,s));O.fragment=(e,t)=>{const s=S(t,e);return new j(s)};class wt{constructor(t,s,n){this.template=t,this.selector=s,this.renderKit=n,this.dom=[]}renderAndAttach(t){this.parentElement=this.getParentElement(),this.dom=this.render({...t,parent:this.parentElement}),this.parentElement&&this.attach()}render(t){return this.template.render(t)}attach(){this.parentElement&&(this.parentElement.innerHTML=""),this.dom.forEach(t=>{this.parentElement&&this.parentElement.appendChild(t)})}getParentElement(){return this.renderKit.document.querySelector(this.selector)}}const Nt=(e,t,s)=>{const n=new wt(e,t,s);return n.renderAndAttach(s),n},M="go-to-href",k="go-to",b="navigation:location-change",$="navigation:route-change",_t=Object.freeze(Object.defineProperty({__proto__:null,linkNavigationEvent:M,locationChangeEvent:b,navigationEvent:k,routeChangeEvent:$},Symbol.toStringTag,{value:"Module"})),D=e=>{e.create("route",{host:"",path:"",query:{}})},P=e=>{const t=e.closest("[href]");return t&&t.getAttribute("href")||""},y=(e,{publish:t,window:s})=>{s.history.pushState(null,"",e),t(b,null)},V=(e,t)=>{if(!e||!e.target)return;e.preventDefault();const s=P(e.target);y(s,t)},F=e=>e.replace(/^\?/,"").split("&").reduce((t,s)=>{if(!s)return t;const n=s.split("=");return t[n[0]]=n[1],t},{}),L=(e,t)=>{const{state:s,publish:n,window:r}=t,{host:i,pathname:a,search:l}=r.location,u=a,d=F(l),c={host:i,path:u,query:d};s.store("route").update(c),n($,c)},z=e=>{const{subscribe:t}=e;t(M,V),t(k,(s,n)=>{y(s,n)})},B=e=>{const{publish:t,subscribe:s,state:n,window:r}=e;D(n),r.addEventListener("popstate",()=>t(b,null)),s(b,L)},K=e=>{setTimeout(()=>e.publish(b,null),0)},R=e=>{B(e),z(e),K(e)},St=Object.freeze(Object.defineProperty({__proto__:null,publishLocation:K,startNavigation:R,subscribeToHistoryChange:B,subscribeToNavigation:z},Symbol.toStringTag,{value:"Module"}));class U{constructor({window:t,document:s,publish:n,subscribe:r,bus:i,state:a,renderKit:l}){this.window=t,this.document=s,this.publish=n,this.subscribe=r,this.bus=i,this.state=a,this.renderKit=l,this.roots=[]}render(t,s){const n=Nt(t,s,this.renderKit);return this.roots.push(n),n}startNavigation(){R(this)}}const Tt=Object.freeze(Object.defineProperty({__proto__:null,App:U},Symbol.toStringTag,{value:"Module"}));class C{constructor(){this.lookup={}}add(t,s,n){this.ensureArrayFor(t);const r={listener:s,index:n,matcher:t};return this.lookup[t].push(r),()=>this.remove(r)}remove(t){this.lookup[t.matcher]&&(this.lookup[t.matcher]=this.lookup[t.matcher].reduce((s,n)=>(n!==t&&s.push(n),s),[]))}matches(t){return this.lookup[t]||[]}ensureArrayFor(t){this.lookup[t]||(this.lookup[t]=[])}}class I{constructor(){this.lookup=[]}add(t,s,n){const r={listener:s,index:n,matcher:t};return this.lookup.push(r),()=>this.remove(r)}remove(t){this.lookup=this.lookup.reduce((s,n)=>(n!==t&&s.push(n),s),[])}matches(t){return this.lookup.filter(s=>s.matcher.test(t))}}class jt{constructor({publish:t,event:s,payload:n,timer:r}){this.setNewTimeout=()=>{this.stopped||setTimeout(()=>{this.publishEvent(),this.setNewTimeout()},this.calculateNextTime())},this.calculateNextTime=()=>this.timer({timeDiff:this.diff(),callCount:this.callCount,stop:this.stop}),this.publish=t,this.event=s,this.payload=n||null,this.stop=this.stopTimeout.bind(this),this.stopped=!1,this.timer=r,this.startedAt=new Date().getTime(),this.callCount=0}start(){this.setNewTimeout()}diff(){return new Date().getTime()-this.startedAt}stopTimeout(){this.stopped=!0,this.timeoutId&&clearTimeout(this.timeoutId)}publishEvent(){this.stopped||(this.callCount+=1,this.publish(this.event,this.payload))}}const Ot=e=>{const{offset:t,period:s}=e,n=({callCount:r})=>t&&r==0?t:s;return{event:e.event,publish:e.publish,payload:e.payload,timer:n}},Mt=e=>{let t;"timer"in e?t=e:t=Ot(e);const s=new jt(t);return s.start(),s.stop};class q{constructor(){this.exactSubscriptions=new C,this.fuzzySubscriptions=new I,this.currentIndex=0}subscribe(t,s){let n;return typeof t=="string"?n=this.exactSubscriptions.add(t,s,this.currentIndex):n=this.fuzzySubscriptions.add(t,s,this.currentIndex),this.currentIndex+=1,n}publish(t,s){[...this.exactSubscriptions.matches(t),...this.fuzzySubscriptions.matches(t)].sort((r,i)=>r.index-i.index).forEach(r=>{r.listener(s,this.listenerOptions(t))})}addListenerOptions(t){this.options=t}listenerOptions(t){return{eventName:t,...this.options,publish:this.publish.bind(this)}}}const J=()=>{const e=new q;return{bus:e,publish:(n,r)=>e.publish(n,r),subscribe:(n,r)=>e.subscribe(n,r)}},kt=Object.freeze(Object.defineProperty({__proto__:null,ExactSubscriptions:C,FuzzySubscriptions:I,JaxsBus:q,createBus:J,publishPeriodically:Mt},Symbol.toStringTag,{value:"Module"})),v=e=>Array.isArray(e),E=e=>e!==null&&!v(e)&&typeof e=="object",$t=(e,t)=>e===t,Dt=(e,t)=>Object.keys(e).length===Object.keys(t).length,Pt=(e,t)=>!(E(e)&&E(t))||!Dt(e,t)?!1:Object.keys(e).every(s=>{const n=e[s],r=t[s];return A(n,r)}),Vt=(e,t)=>!(v(e)&&v(t))||e.length!==t.length?!1:e.every((s,n)=>{const r=t[n];return A(s,r)}),A=(e,t)=>E(e)?Pt(e,t):v(e)?Vt(e,t):$t(e,t);class x{constructor(t){this.name=t.name,this.parent=t.parent,this._value=t.value,this.initialValue=structuredClone(t.value)}get value(){return this._value}set value(t){throw new Error("Cannot set value directly. Use an updater!")}reset(){this._value=this.initialValue}update(t){if(typeof t=="function"){const s=this.getUpdatedValue(t);this.updateValue(s)}else this.updateValue(t)}updateValue(t){A(this._value,t)||(this._value=t,this.parent.notify(this.name))}getUpdatedValue(t){return t(this.value)}}class w{constructor(t){this.store=t}update(t){this.store.update(t)}reset(){this.store.update(this.store.initialValue)}get value(){return this.store.value}}class Ft extends w{updateAttribute(t,s){const n={...this.value};n[t]=s,this.update(n)}updateDynamicAttribute(t,s){this.isKey(t)&&this.isValueType(t,s)&&this.updateAttribute(t,s)}isKey(t){return t in this.store.initialValue}isValueType(t,s){return typeof this.store.initialValue[t]==typeof s}resetAttribute(t){const s={...this.value},n=this.store.initialValue[t];s[t]=n,this.update(s)}}const Lt=e=>new Ft(e);class zt extends w{push(t){const s=[...this.value,t];this.update(s)}pop(){const t=[...this.value],s=t.pop();return this.update(t),s}unshift(t){const s=[t,...this.value];this.update(s)}shift(){const t=[...this.value],s=t.shift();return this.update(t),s}addSorter(t,s){this[t]=()=>{this.sortBy(s)}}sortBy(t){const s=[...this.value];s.sort(t),this.update(s)}insertAt(t,s){const n=[...this.value];n.splice(t,0,s),this.update(n)}remove(t){const s=this.value.reduce((n,r)=>(r!==t&&n.push(r),n),[]);this.update(s)}removeBy(t){const s=this.value.reduce((n,r)=>(t(r)||n.push(r),n),[]);this.update(s)}}const Bt=e=>new zt(e);class Kt extends w{toggle(){const t=!this.value;this.update(t)}setTrue(){this.update(!0)}setFalse(){this.update(!1)}}const Rt={object:Lt,list:Bt,boolean:e=>new Kt(e)},N="state";class G{constructor(t){this.publisher=t,this.stores={},this.eventNamePrefix=N,this.notifications=new Set,this.inTransaction=!1}create(t,s){const n=new x({name:t,parent:this,value:s});return this.stores[t]=n,n}store(t){return this.stores[t]||new x({name:t,parent:this,value:void 0})}get(t){return this.store(t).value}getAll(t){return t.reduce((s,n)=>(s[n]=this.get(n),s),{})}notify(t){this.inTransaction?this.notifications.add(t):this.publish(t)}update(t,s){this.store(t).update(s)}transaction(t){this.inTransaction=!0,t(this.stores),this.inTransaction=!1,this.publishAll()}publishAll(){this.notifications.forEach(t=>{this.publish(t)}),this.notifications.clear()}publish(t){this.publisher(this.event(t),{state:this,store:this.store(t)})}event(t){return`${this.eventNamePrefix}:${t}`}}const H=e=>new G(e),Ut=Object.freeze(Object.defineProperty({__proto__:null,State:G,Store:x,createState:H,eventName:N,updaters:Rt},Symbol.toStringTag,{value:"Module"}));class Ct{constructor(t){this.setupDomEnvironment(t)}setup(){return this.setupBus(),this.setupState(),this.addBusOptions(),this.setRenderKit(),new U({window:this.window,document:this.document,publish:this.publish,subscribe:this.subscribe,bus:this.bus,state:this.state,renderKit:this.renderKit})}setupDomEnvironment(t){t.window?(this.window=t.window,this.document=this.window.document):t.document?(this.window=t.document.defaultView,this.document=t.document):(this.window=window,this.document=document)}setupBus(){const{publish:t,subscribe:s,bus:n}=J();this.publish=t,this.subscribe=s,this.bus=n}setupState(){this.state=H(this.publish)}addBusOptions(){this.bus.addListenerOptions({state:this.state,document:this.document,window:this.window})}setRenderKit(){this.renderKit={publish:this.publish,subscribe:this.subscribe,state:this.state,document:this.document,window:this.window}}}const It=(e={})=>{const s=new Ct(e).setup();return s.startNavigation(),s};var o=(e=>(e[e.removeNode=0]="removeNode",e[e.insertNode=1]="insertNode",e[e.replaceNode=2]="replaceNode",e[e.removeAttribute=3]="removeAttribute",e[e.addAttribute=4]="addAttribute",e[e.updateAttribute=5]="updateAttribute",e[e.removeEvent=6]="removeEvent",e[e.addEvent=7]="addEvent",e[e.updateEvent=8]="updateEvent",e[e.changeValue=9]="changeValue",e[e.changeText=10]="changeText",e))(o||{});const qt=Object.freeze(Object.defineProperty({__proto__:null,ChangeInstructionTypes:o},Symbol.toStringTag,{value:"Module"})),Jt=(e,t)=>({source:e,target:t,type:o.changeText,data:{}}),Gt=(e,t)=>({source:e,target:t,type:o.replaceNode,data:{}}),Ht=(e,t,s)=>({source:e,target:t,data:s,type:o.removeAttribute}),Qt=(e,t,s)=>({source:e,target:t,data:s,type:o.addAttribute}),Wt=(e,t,s)=>({source:e,target:t,data:s,type:o.updateAttribute}),Xt=(e,t,s)=>({source:e,target:t,data:s,type:o.removeEvent}),Yt=(e,t,s)=>({source:e,target:t,data:s,type:o.addEvent}),Zt=(e,t,s)=>({source:e,target:t,data:s,type:o.updateEvent}),Q=e=>({source:e,target:e,type:o.removeNode,data:{}}),_=(e,t)=>({target:e,source:e,type:o.insertNode,data:t}),te=(e,t,s)=>({source:e,target:t,type:o.changeValue,data:s}),ee=(e,t)=>e.type>t.type?1:e.type<t.type?-1:0,W={index:-1};class se{constructor(){this.map={}}populate(t){t.forEach((s,n)=>{const r=s.__jsx;r&&(this.map[r]=this.map[r]||[],this.map[r].push({element:s,index:n}))})}pullMatch(t){const s=t&&t.__jsx;return!s||!(this.map[s]&&this.map[s].length)?W:this.map[s].shift()}clear(t){const s=t&&t.__jsx;if(!(s&&this.map[s]&&this.map[s].length))return;const n=this.map[s];this.map[s]=n.reduce((r,i)=>(i.element!==t&&r.push(i),r),[])}check(t){const s=t&&t.__jsx;return s&&this.map[s]?this.map[s].length>0:!1}remaining(){return Object.values(this.map).flat()}}const X=e=>{const t=new se;return t.populate(e),t},Y=(e,t,s=!1)=>{const n=[],r=e.attributes,i=r.length,a=t.attributes,l=a.length;let u,d,c;for(u=0;u<i;u++){c=null;const h=r.item(u);if(h){for(d=0;d<l;d++){const m=a.item(d);if(m&&h.name==m.name){c=m;break}}c?h.value!==c.value&&n.push(Wt(e,t,{name:h.name,value:c.value,isSvg:s})):n.push(Ht(e,t,{name:h.name,isSvg:s}))}}for(u=0;u<l;u++){c=null;const h=a.item(u);if(h){for(d=0;d<i;d++){const m=r.item(d);if(m&&m.name==h.name){c=m;break}}c||n.push(Qt(e,t,{name:h.name,value:h.value,isSvg:s}))}}return n},ne=(e,t)=>{const s=[],n=e.eventMaps,r=t.eventMaps,i=Object.keys(n),a=Object.keys(r);return i.forEach(l=>{const u=n[l],d=r[l];d?d.busEvent!==u.busEvent&&s.push(Zt(e,t,{name:l,targetValue:d.listener,sourceValue:u.listener})):s.push(Xt(e,t,{name:u.domEvent,value:u.listener}))}),a.forEach(l=>{const u=n[l],d=r[l];u||s.push(Yt(e,t,{name:d.domEvent,value:d.listener}))}),s},re=e=>e.tagName!=="INPUT",ie=(e,t)=>e.value===t.value,oe=(e,t)=>{if(re(e)||ie(e,t))return[];const s=e,n=t;return[te(s,n,{name:"value",value:n.value})]},ue=(e,t)=>{const s=Y(e,t),n=ne(e,t),r=oe(e,t);return s.concat(n).concat(r)},ae=(e,t)=>Y(e,t,!0),ce=(e,t)=>e.textContent!==t.textContent?[Jt(e,t)]:[],le=(e,t,s)=>{let n=[];if(e.nodeType===1&&ct(e)){const r=e,i=t,a=ae(r,i),l=s(r.childNodes,i.childNodes,r);n=a.concat(l)}else if(e.nodeType===1){const r=e,i=t,a=ue(r,i),l=s(r.childNodes,i.childNodes,r);n=a.concat(l)}else e.nodeType===3&&(n=ce(e,t));return n},Z=(e,t,s)=>{const n=[],r=he(e,t),i=X(e),a=X(t),l=[];let u=0;for(;u<r;u++){const c=e[u],h=t[u];if(h&&a.check(h)){const m=i.pullMatch(h);a.clear(h),m.element?(m.index!==u&&n.push(_(m.element,{parent:s,index:u})),l.push({source:m.element,target:h})):c?a.check(c)?n.push(_(h,{parent:s,index:u})):(i.clear(c),n.push(Gt(c,h))):n.push(_(h,{parent:s,index:u}))}else c&&i.pullMatch(c).element&&n.push(Q(c))}i.remaining().forEach(({element:c})=>{n.push(Q(c))});const d=l.reduce((c,{source:h,target:m})=>c.concat(le(h,m,Z)),[]);return n.concat(d).sort(ee)},he=(e,t)=>{const s=e.length,n=t.length;return s>n?s:n},de=(e,t,s)=>{const n=Z(e,t,s);return n.forEach(r=>{pe(r)}),n},pe=e=>{(_e[e.type]||me)(e)},me=e=>{},fe=e=>{const{source:t,target:s}=e;t.nodeValue=s.textContent},be=e=>{const{source:t}=e;t.remove()},ve=e=>{const{target:t,data:s}=e,{parent:n,index:r}=s,i=n.childNodes[r];i?i&&i!==t&&n.insertBefore(t,i):n.appendChild(t)},ge=e=>{const{source:t,target:s}=e;t.replaceWith(s)},ye=e=>{const{source:t,data:s}=e,{name:n,isSvg:r}=s;r?t.removeAttributeNS(null,n):t.removeAttribute(n)},tt=e=>{const{source:t,data:s}=e,{name:n,value:r,isSvg:i}=s;i?t.setAttributeNS(null,n,r):t.setAttribute(n,r)},Ee=e=>{tt(e)},Ae=e=>{const t=e.data,s=e.source,{name:n,value:r}=t;s.removeEventListener(n,r)},xe=e=>{const t=e.data,s=e.source,{name:n,value:r}=t;s.addEventListener(n,r)},we=e=>{const t=e.data,s=e.source,{name:n,sourceValue:r,targetValue:i}=t;s.removeEventListener(n,r),s.addEventListener(n,i)},Ne=e=>{const t=e.data,s=e.source,{value:n}=t;s.value=n},_e={[o.changeText]:fe,[o.removeNode]:be,[o.insertNode]:ve,[o.replaceNode]:ge,[o.removeAttribute]:ye,[o.addAttribute]:tt,[o.updateAttribute]:Ee,[o.removeEvent]:Ae,[o.addEvent]:xe,[o.updateEvent]:we,[o.changeValue]:Ne},Se=(e,t,s)=>{const n=[...t];return e.forEach(r=>{Te(r,n,s)}),n},Te=(e,t,s)=>{const n=ke[e.type];n&&n(e,t,s)},je=(e,t)=>{const{source:s}=e,n=t.indexOf(s);n>=0&&t.splice(n,1)},Oe=(e,t,s)=>{const{target:n}=e,r=e.data,{index:i,parent:a}=r;s===a&&t.splice(i,0,n)},Me=(e,t)=>{const{target:s,source:n}=e,r=t.indexOf(n);r>=0&&(t[r]=s)},ke={[o.removeNode]:je,[o.insertNode]:Oe,[o.replaceNode]:Me};class $e{constructor({Template:t,subscriptions:s,attributes:n,viewModel:r}){this.Template=t,this.viewModel=r,this.attributes=n,this.subscriptions=s,this.dom=[],this.parentElement=null}render(t){return this.parentElement=t.parent,this.renderKit=t,this.subscribeForRerender(),this.dom=this.generateDom(t),this.dom}generateDom(t){const s={...this.attributes,...this.viewModel(t.state.getAll(this.subscriptions))},n=this.Template(s);return n?n.render(t):[]}rerender(){if(!this.parentElement&&this.dom[0]){const n=this.dom[0].parentElement;this.parentElement=n}const t=this.generateDom(this.renderKit),s=de(this.dom,t,this.parentElement);this.dom=Se(s,this.dom,this.parentElement)}subscribeForRerender(){const{subscribe:t}=this.renderKit;this.subscriptions.forEach(s=>{t(this.eventName(s),()=>this.rerender())})}eventName(t){return`${N}:${t}`}}const De=e=>e,et=({Template:e,viewModel:t,subscriptions:s})=>(s=s||[],t=t||De,n=>new $e({Template:e,viewModel:t,subscriptions:s,attributes:n})),Pe=Object.freeze(Object.defineProperty({__proto__:null,createRouteState:D,events:_t,extractQueryParams:F,findHref:P,navigate:y,onLinkClick:V,onLocationChange:L,start:St},Symbol.toStringTag,{value:"Module"})),Ve=e=>({path:t})=>t===e,Fe=()=>!0,st=e=>({route:t})=>{const s=e.find(n=>n.match(t));return s&&s.Partial},Le=Object.freeze(Object.defineProperty({__proto__:null,buildRouter:st,catchAll:Fe,exactPathMatch:Ve},Symbol.toStringTag,{value:"Module"})),ze=()=>({render:(e,t)=>[]}),Be=e=>{const t=st(e);return et({Template:({route:n})=>(t({route:n})||ze)(),subscriptions:["route"]})};p.JaxsTypes=qt,p.appBuilding=Tt,p.bind=et,p.createApp=It,p.jsx=O,p.messageBus=kt,p.navigation=Pe,p.routedView=Be,p.routing=Le,p.state=Ut,Object.defineProperty(p,Symbol.toStringTag,{value:"Module"})});
+;(function (p, f) {
+  typeof exports == 'object' && typeof module < 'u'
+    ? f(exports)
+    : typeof define == 'function' && define.amd
+      ? define(['exports'], f)
+      : ((p = typeof globalThis < 'u' ? globalThis : p || self),
+        f((p.jaxs = {})))
+})(this, function (p) {
+  'use strict'
+  const f = (e, t) => t.createElement(e),
+    nt = (e, t) => {
+      for (const s in t) {
+        if (s === '__self') continue
+        const n = t[s].toString()
+        if (s === 'value') {
+          const r = e
+          r.value !== n && (r.value = n)
+        } else e.setAttribute(s, n)
+      }
+    },
+    rt = (e, t, s) => {
+      const n = {}
+      for (const r in t) {
+        const i = t[r],
+          a = (l) => s(i, l)
+        e.addEventListener(r, a),
+          (n[r] = { domEvent: r, busEvent: i, listener: a })
+      }
+      e.eventMaps = n
+    },
+    it = (e, t, s, n) => {
+      const r = f(e, n.document)
+      return nt(r, t), rt(r, s, n.publish), r
+    },
+    g = 'http://www.w3.org/2000/svg',
+    ot = {
+      animate: !0,
+      animateMotion: !0,
+      animateTransform: !0,
+      circle: !0,
+      clipPath: !0,
+      defs: !0,
+      desc: !0,
+      ellipse: !0,
+      feBlend: !0,
+      feColorMatrix: !0,
+      feComponentTransfer: !0,
+      feComposite: !0,
+      feConvolveMatrix: !0,
+      feDiffuseLighting: !0,
+      feDisplacementMap: !0,
+      feDistantLight: !0,
+      feDropShadow: !0,
+      feFlood: !0,
+      feFuncA: !0,
+      feFuncB: !0,
+      feFuncG: !0,
+      feFuncR: !0,
+      feGaussianBlur: !0,
+      feImage: !0,
+      feMerge: !0,
+      feMergeNode: !0,
+      feMorphology: !0,
+      feOffset: !0,
+      fePointLight: !0,
+      feSpecularLighting: !0,
+      feSpotLight: !0,
+      feTile: !0,
+      feTurbulence: !0,
+      filter: !0,
+      foreignObject: !0,
+      g: !0,
+      image: !0,
+      line: !0,
+      linearGradient: !0,
+      marker: !0,
+      mask: !0,
+      metadata: !0,
+      mpath: !0,
+      path: !0,
+      pattern: !0,
+      polygon: !0,
+      polyline: !0,
+      radialGradient: !0,
+      rect: !0,
+      script: !0,
+      set: !0,
+      stop: !0,
+      style: !0,
+      svg: !0,
+      switch: !0,
+      symbol: !0,
+      text: !0,
+      textPath: !0,
+      title: !0,
+      tspan: !0,
+      use: !0,
+      view: !0,
+    },
+    ut = (e, t) => !!(ot[e] || (e === 'a' && t === g)),
+    at = (e, t, s) => {
+      const n = s.createElementNS(g, e)
+      for (const r in t)
+        r === '__self' ||
+          r === 'xmlns' ||
+          n.setAttributeNS(null, r, t[r].toString())
+      return n
+    },
+    ct = (e) => e.namespaceURI === g,
+    lt = (e, t) => t.createTextNode(e)
+  class ht {
+    constructor(t) {
+      this.value = t.toString()
+    }
+    render(t) {
+      const s = lt(this.value, t.document)
+      return (s.__jsx = 'TextNode'), [s]
+    }
+  }
+  const dt = (e) => typeof e == 'string' || typeof e == 'number',
+    pt = (e) => new ht(e),
+    mt = (e) => (dt(e) ? pt(e) : e),
+    ft = (e) => bt(e).map(mt).flat(),
+    bt = (e) => (Array.isArray(e) ? e.flat() : e ? [e] : []),
+    S = (e, t = {}) => e || t.children || [],
+    vt = (e, t = '') => {
+      const s = {},
+        n = {}
+      for (const r in e) {
+        const i = e[r]
+        if (r.match(/^on.+/i)) {
+          const a = r.slice(2).toLowerCase()
+          n[a] = i ? i.toString() : ''
+        } else {
+          if (i === !1) continue
+          r === '__source' ? (s.__source = e.__source) : (s[r] = gt(r, i, t))
+        }
+      }
+      return { attributes: s, events: n }
+    },
+    gt = (e, t, s = '') => (t == null ? s : t.toString()),
+    yt = (e, t) => {
+      const s = e || {},
+        n = S(t, s)
+      return (s.children = s.children || n), s
+    },
+    T = (e, t, s, n = []) => e.reduce(Et(t, s), n).flat(),
+    Et = (e, t) => (s, n) =>
+      n
+        ? Array.isArray(n)
+          ? T(n, e, t, s)
+          : (n.render(e, t).forEach((r) => s.push(r)), s)
+        : s
+  class j {
+    constructor(t) {
+      this.collection = ft(t)
+    }
+    render(t, s) {
+      this.parentElement = s
+      const n = this.generateDom(t)
+      return this.attachToParent(n), n
+    }
+    generateDom(t) {
+      return T(this.collection, t, this.parentElement)
+    }
+    attachToParent(t) {
+      if (this.parentElement === void 0) return
+      const s = this.parentElement
+      t.forEach((n) => s.appendChild(n))
+    }
+  }
+  class At {
+    constructor(t, s) {
+      ;(this.type = t), (this.attributes = s)
+    }
+    generate() {
+      return (
+        this.attributes.key ||
+        this.sourceKey() ||
+        this.createKeyFromAttributes()
+      )
+    }
+    sourceKey() {
+      if (this.attributes.__source) {
+        const {
+          fileName: t,
+          lineNumber: s,
+          columnNumber: n,
+        } = this.attributes.__source
+        return `${t}:${s}:${n}`
+      }
+    }
+    createKeyFromAttributes() {
+      const t = this.attributes.id ? `#${this.attributes.id}` : '',
+        s = this.attributes.type ? `[type=${this.attributes.type}]` : '',
+        n = this.attributes.name ? `[name=${this.attributes.name}]` : ''
+      return `${this.type}${t}${s}${n}`
+    }
+  }
+  class xt {
+    constructor(t, s, n = []) {
+      this.type = t
+      const { events: r, attributes: i } = vt(s)
+      ;(this.events = r),
+        (this.attributes = i),
+        (this.isSvg = ut(this.type, this.attributes.xmlns)),
+        (this.children = new j(n))
+    }
+    render(t) {
+      const s = this.generateDom(t)
+      return s ? (this.children.render(t, s), [s]) : []
+    }
+    generateDom(t) {
+      return this.isSvg ? this.generateSvgDom(t) : this.generateHtmlDom(t)
+    }
+    generateHtmlDom(t) {
+      const s = it(this.type, this.attributes, this.events, t)
+      return (s.__jsx = this.jsxKey()), s
+    }
+    generateSvgDom(t) {
+      const s = at(this.type, this.attributes, t.document)
+      return (s.__jsx = this.jsxKey()), s
+    }
+    jsxKey() {
+      return new At(this.type, this.attributes).generate()
+    }
+  }
+  const O = (e, t, ...s) =>
+    typeof e == 'string' ? new xt(e, t, s) : e(yt(t, s))
+  O.fragment = (e, t) => {
+    const s = S(t, e)
+    return new j(s)
+  }
+  class wt {
+    constructor(t, s, n) {
+      ;(this.template = t),
+        (this.selector = s),
+        (this.renderKit = n),
+        (this.dom = [])
+    }
+    renderAndAttach(t) {
+      ;(this.parentElement = this.getParentElement()),
+        (this.dom = this.render({ ...t, parent: this.parentElement })),
+        this.parentElement && this.attach()
+    }
+    render(t) {
+      return this.template.render(t)
+    }
+    attach() {
+      this.parentElement && (this.parentElement.innerHTML = ''),
+        this.dom.forEach((t) => {
+          this.parentElement && this.parentElement.appendChild(t)
+        })
+    }
+    getParentElement() {
+      return this.renderKit.document.querySelector(this.selector)
+    }
+  }
+  const Nt = (e, t, s) => {
+      const n = new wt(e, t, s)
+      return n.renderAndAttach(s), n
+    },
+    M = 'go-to-href',
+    k = 'go-to',
+    b = 'navigation:location-change',
+    $ = 'navigation:route-change',
+    _t = Object.freeze(
+      Object.defineProperty(
+        {
+          __proto__: null,
+          linkNavigationEvent: M,
+          locationChangeEvent: b,
+          navigationEvent: k,
+          routeChangeEvent: $,
+        },
+        Symbol.toStringTag,
+        { value: 'Module' },
+      ),
+    ),
+    D = (e) => {
+      e.create('route', { host: '', path: '', query: {} })
+    },
+    P = (e) => {
+      const t = e.closest('[href]')
+      return (t && t.getAttribute('href')) || ''
+    },
+    y = (e, { publish: t, window: s }) => {
+      s.history.pushState(null, '', e), t(b, null)
+    },
+    V = (e, t) => {
+      if (!e || !e.target) return
+      e.preventDefault()
+      const s = P(e.target)
+      y(s, t)
+    },
+    F = (e) =>
+      e
+        .replace(/^\?/, '')
+        .split('&')
+        .reduce((t, s) => {
+          if (!s) return t
+          const n = s.split('=')
+          return (t[n[0]] = n[1]), t
+        }, {}),
+    L = (e, t) => {
+      const { state: s, publish: n, window: r } = t,
+        { host: i, pathname: a, search: l } = r.location,
+        u = a,
+        d = F(l),
+        c = { host: i, path: u, query: d }
+      s.store('route').update(c), n($, c)
+    },
+    z = (e) => {
+      const { subscribe: t } = e
+      t(M, V),
+        t(k, (s, n) => {
+          y(s, n)
+        })
+    },
+    B = (e) => {
+      const { publish: t, subscribe: s, state: n, window: r } = e
+      D(n), r.addEventListener('popstate', () => t(b, null)), s(b, L)
+    },
+    K = (e) => {
+      setTimeout(() => e.publish(b, null), 0)
+    },
+    R = (e) => {
+      B(e), z(e), K(e)
+    },
+    St = Object.freeze(
+      Object.defineProperty(
+        {
+          __proto__: null,
+          publishLocation: K,
+          startNavigation: R,
+          subscribeToHistoryChange: B,
+          subscribeToNavigation: z,
+        },
+        Symbol.toStringTag,
+        { value: 'Module' },
+      ),
+    )
+  class U {
+    constructor({
+      window: t,
+      document: s,
+      publish: n,
+      subscribe: r,
+      bus: i,
+      state: a,
+      renderKit: l,
+    }) {
+      ;(this.window = t),
+        (this.document = s),
+        (this.publish = n),
+        (this.subscribe = r),
+        (this.bus = i),
+        (this.state = a),
+        (this.renderKit = l),
+        (this.roots = [])
+    }
+    render(t, s) {
+      const n = Nt(t, s, this.renderKit)
+      return this.roots.push(n), n
+    }
+    startNavigation() {
+      R(this)
+    }
+  }
+  const Tt = Object.freeze(
+    Object.defineProperty({ __proto__: null, App: U }, Symbol.toStringTag, {
+      value: 'Module',
+    }),
+  )
+  class C {
+    constructor() {
+      this.lookup = {}
+    }
+    add(t, s, n) {
+      this.ensureArrayFor(t)
+      const r = { listener: s, index: n, matcher: t }
+      return this.lookup[t].push(r), () => this.remove(r)
+    }
+    remove(t) {
+      this.lookup[t.matcher] &&
+        (this.lookup[t.matcher] = this.lookup[t.matcher].reduce(
+          (s, n) => (n !== t && s.push(n), s),
+          [],
+        ))
+    }
+    matches(t) {
+      return this.lookup[t] || []
+    }
+    ensureArrayFor(t) {
+      this.lookup[t] || (this.lookup[t] = [])
+    }
+  }
+  class I {
+    constructor() {
+      this.lookup = []
+    }
+    add(t, s, n) {
+      const r = { listener: s, index: n, matcher: t }
+      return this.lookup.push(r), () => this.remove(r)
+    }
+    remove(t) {
+      this.lookup = this.lookup.reduce((s, n) => (n !== t && s.push(n), s), [])
+    }
+    matches(t) {
+      return this.lookup.filter((s) => s.matcher.test(t))
+    }
+  }
+  class jt {
+    constructor({ publish: t, event: s, payload: n, timer: r }) {
+      ;(this.setNewTimeout = () => {
+        this.stopped ||
+          setTimeout(() => {
+            this.publishEvent(), this.setNewTimeout()
+          }, this.calculateNextTime())
+      }),
+        (this.calculateNextTime = () =>
+          this.timer({
+            timeDiff: this.diff(),
+            callCount: this.callCount,
+            stop: this.stop,
+          })),
+        (this.publish = t),
+        (this.event = s),
+        (this.payload = n || null),
+        (this.stop = this.stopTimeout.bind(this)),
+        (this.stopped = !1),
+        (this.timer = r),
+        (this.startedAt = new Date().getTime()),
+        (this.callCount = 0)
+    }
+    start() {
+      this.setNewTimeout()
+    }
+    diff() {
+      return new Date().getTime() - this.startedAt
+    }
+    stopTimeout() {
+      ;(this.stopped = !0), this.timeoutId && clearTimeout(this.timeoutId)
+    }
+    publishEvent() {
+      this.stopped ||
+        ((this.callCount += 1), this.publish(this.event, this.payload))
+    }
+  }
+  const Ot = (e) => {
+      const { offset: t, period: s } = e,
+        n = ({ callCount: r }) => (t && r == 0 ? t : s)
+      return {
+        event: e.event,
+        publish: e.publish,
+        payload: e.payload,
+        timer: n,
+      }
+    },
+    Mt = (e) => {
+      let t
+      'timer' in e ? (t = e) : (t = Ot(e))
+      const s = new jt(t)
+      return s.start(), s.stop
+    }
+  class q {
+    constructor() {
+      ;(this.exactSubscriptions = new C()),
+        (this.fuzzySubscriptions = new I()),
+        (this.currentIndex = 0)
+    }
+    subscribe(t, s) {
+      let n
+      return (
+        typeof t == 'string'
+          ? (n = this.exactSubscriptions.add(t, s, this.currentIndex))
+          : (n = this.fuzzySubscriptions.add(t, s, this.currentIndex)),
+        (this.currentIndex += 1),
+        n
+      )
+    }
+    publish(t, s) {
+      ;[
+        ...this.exactSubscriptions.matches(t),
+        ...this.fuzzySubscriptions.matches(t),
+      ]
+        .sort((r, i) => r.index - i.index)
+        .forEach((r) => {
+          r.listener(s, this.listenerOptions(t))
+        })
+    }
+    addListenerOptions(t) {
+      this.options = t
+    }
+    listenerOptions(t) {
+      return { eventName: t, ...this.options, publish: this.publish.bind(this) }
+    }
+  }
+  const J = () => {
+      const e = new q()
+      return {
+        bus: e,
+        publish: (n, r) => e.publish(n, r),
+        subscribe: (n, r) => e.subscribe(n, r),
+      }
+    },
+    kt = Object.freeze(
+      Object.defineProperty(
+        {
+          __proto__: null,
+          ExactSubscriptions: C,
+          FuzzySubscriptions: I,
+          JaxsBus: q,
+          createBus: J,
+          publishPeriodically: Mt,
+        },
+        Symbol.toStringTag,
+        { value: 'Module' },
+      ),
+    ),
+    v = (e) => Array.isArray(e),
+    E = (e) => e !== null && !v(e) && typeof e == 'object',
+    $t = (e, t) => e === t,
+    Dt = (e, t) => Object.keys(e).length === Object.keys(t).length,
+    Pt = (e, t) =>
+      !(E(e) && E(t)) || !Dt(e, t)
+        ? !1
+        : Object.keys(e).every((s) => {
+            const n = e[s],
+              r = t[s]
+            return A(n, r)
+          }),
+    Vt = (e, t) =>
+      !(v(e) && v(t)) || e.length !== t.length
+        ? !1
+        : e.every((s, n) => {
+            const r = t[n]
+            return A(s, r)
+          }),
+    A = (e, t) => (E(e) ? Pt(e, t) : v(e) ? Vt(e, t) : $t(e, t))
+  class x {
+    constructor(t) {
+      ;(this.name = t.name),
+        (this.parent = t.parent),
+        (this._value = structuredClone(t.value)),
+        (this.initialValue = structuredClone(t.value))
+    }
+    get value() {
+      return this._value
+    }
+    set value(t) {
+      throw new Error('Cannot set value directly. Use an updater!')
+    }
+    reset() {
+      this._value = structuredClone(this.initialValue)
+    }
+    update(t) {
+      if (typeof t == 'function') {
+        const s = this.getUpdatedValue(t)
+        this.updateValue(s)
+      } else this.updateValue(t)
+    }
+    updateValue(t) {
+      A(this._value, t) || ((this._value = t), this.parent.notify(this.name))
+    }
+    getUpdatedValue(t) {
+      return t(structuredClone(this.value))
+    }
+  }
+  class w {
+    constructor(t) {
+      this.store = t
+    }
+    update(t) {
+      this.store.update(t)
+    }
+    reset() {
+      this.store.update(this.store.initialValue)
+    }
+    get value() {
+      return this.store.value
+    }
+  }
+  class Ft extends w {
+    updateAttribute(t, s) {
+      const n = { ...this.value }
+      ;(n[t] = s), this.update(n)
+    }
+    updateDynamicAttribute(t, s) {
+      this.isKey(t) && this.isValueType(t, s) && this.updateAttribute(t, s)
+    }
+    isKey(t) {
+      return t in this.store.initialValue
+    }
+    isValueType(t, s) {
+      return typeof this.store.initialValue[t] == typeof s
+    }
+    resetAttribute(t) {
+      const s = { ...this.value },
+        n = this.store.initialValue[t]
+      ;(s[t] = n), this.update(s)
+    }
+  }
+  const Lt = (e) => new Ft(e)
+  class zt extends w {
+    push(t) {
+      const s = [...this.value, t]
+      this.update(s)
+    }
+    pop() {
+      const t = [...this.value],
+        s = t.pop()
+      return this.update(t), s
+    }
+    unshift(t) {
+      const s = [t, ...this.value]
+      this.update(s)
+    }
+    shift() {
+      const t = [...this.value],
+        s = t.shift()
+      return this.update(t), s
+    }
+    addSorter(t, s) {
+      this[t] = () => {
+        this.sortBy(s)
+      }
+    }
+    sortBy(t) {
+      const s = [...this.value]
+      s.sort(t), this.update(s)
+    }
+    insertAt(t, s) {
+      const n = [...this.value]
+      n.splice(t, 0, s), this.update(n)
+    }
+    remove(t) {
+      const s = this.value.reduce((n, r) => (r !== t && n.push(r), n), [])
+      this.update(s)
+    }
+    removeBy(t) {
+      const s = this.value.reduce((n, r) => (t(r) || n.push(r), n), [])
+      this.update(s)
+    }
+  }
+  const Bt = (e) => new zt(e)
+  class Kt extends w {
+    toggle() {
+      const t = !this.value
+      this.update(t)
+    }
+    setTrue() {
+      this.update(!0)
+    }
+    setFalse() {
+      this.update(!1)
+    }
+  }
+  const Rt = { object: Lt, list: Bt, boolean: (e) => new Kt(e) },
+    N = 'state'
+  class G {
+    constructor(t) {
+      ;(this.publisher = t),
+        (this.stores = {}),
+        (this.eventNamePrefix = N),
+        (this.notifications = new Set()),
+        (this.inTransaction = !1)
+    }
+    create(t, s) {
+      const n = new x({ name: t, parent: this, value: s })
+      return (this.stores[t] = n), n
+    }
+    store(t) {
+      return this.stores[t] || new x({ name: t, parent: this, value: void 0 })
+    }
+    get(t) {
+      return this.store(t).value
+    }
+    getAll(t) {
+      return t.reduce((s, n) => ((s[n] = this.get(n)), s), {})
+    }
+    notify(t) {
+      this.inTransaction ? this.notifications.add(t) : this.publish(t)
+    }
+    update(t, s) {
+      this.store(t).update(s)
+    }
+    transaction(t) {
+      ;(this.inTransaction = !0),
+        t(this.stores),
+        (this.inTransaction = !1),
+        this.publishAll()
+    }
+    publishAll() {
+      this.notifications.forEach((t) => {
+        this.publish(t)
+      }),
+        this.notifications.clear()
+    }
+    publish(t) {
+      this.publisher(this.event(t), { state: this, store: this.store(t) })
+    }
+    event(t) {
+      return `${this.eventNamePrefix}:${t}`
+    }
+  }
+  const H = (e) => new G(e),
+    Ut = Object.freeze(
+      Object.defineProperty(
+        {
+          __proto__: null,
+          State: G,
+          Store: x,
+          createState: H,
+          eventName: N,
+          updaters: Rt,
+        },
+        Symbol.toStringTag,
+        { value: 'Module' },
+      ),
+    )
+  class Ct {
+    constructor(t) {
+      this.setupDomEnvironment(t)
+    }
+    setup() {
+      return (
+        this.setupBus(),
+        this.setupState(),
+        this.addBusOptions(),
+        this.setRenderKit(),
+        new U({
+          window: this.window,
+          document: this.document,
+          publish: this.publish,
+          subscribe: this.subscribe,
+          bus: this.bus,
+          state: this.state,
+          renderKit: this.renderKit,
+        })
+      )
+    }
+    setupDomEnvironment(t) {
+      t.window
+        ? ((this.window = t.window), (this.document = this.window.document))
+        : t.document
+          ? ((this.window = t.document.defaultView),
+            (this.document = t.document))
+          : ((this.window = window), (this.document = document))
+    }
+    setupBus() {
+      const { publish: t, subscribe: s, bus: n } = J()
+      ;(this.publish = t), (this.subscribe = s), (this.bus = n)
+    }
+    setupState() {
+      this.state = H(this.publish)
+    }
+    addBusOptions() {
+      this.bus.addListenerOptions({
+        state: this.state,
+        document: this.document,
+        window: this.window,
+      })
+    }
+    setRenderKit() {
+      this.renderKit = {
+        publish: this.publish,
+        subscribe: this.subscribe,
+        state: this.state,
+        document: this.document,
+        window: this.window,
+      }
+    }
+  }
+  const It = (e = {}) => {
+    const s = new Ct(e).setup()
+    return s.startNavigation(), s
+  }
+  var o = ((e) => (
+    (e[(e.removeNode = 0)] = 'removeNode'),
+    (e[(e.insertNode = 1)] = 'insertNode'),
+    (e[(e.replaceNode = 2)] = 'replaceNode'),
+    (e[(e.removeAttribute = 3)] = 'removeAttribute'),
+    (e[(e.addAttribute = 4)] = 'addAttribute'),
+    (e[(e.updateAttribute = 5)] = 'updateAttribute'),
+    (e[(e.removeEvent = 6)] = 'removeEvent'),
+    (e[(e.addEvent = 7)] = 'addEvent'),
+    (e[(e.updateEvent = 8)] = 'updateEvent'),
+    (e[(e.changeValue = 9)] = 'changeValue'),
+    (e[(e.changeText = 10)] = 'changeText'),
+    e
+  ))(o || {})
+  const qt = Object.freeze(
+      Object.defineProperty(
+        { __proto__: null, ChangeInstructionTypes: o },
+        Symbol.toStringTag,
+        { value: 'Module' },
+      ),
+    ),
+    Jt = (e, t) => ({ source: e, target: t, type: o.changeText, data: {} }),
+    Gt = (e, t) => ({ source: e, target: t, type: o.replaceNode, data: {} }),
+    Ht = (e, t, s) => ({
+      source: e,
+      target: t,
+      data: s,
+      type: o.removeAttribute,
+    }),
+    Qt = (e, t, s) => ({ source: e, target: t, data: s, type: o.addAttribute }),
+    Wt = (e, t, s) => ({
+      source: e,
+      target: t,
+      data: s,
+      type: o.updateAttribute,
+    }),
+    Xt = (e, t, s) => ({ source: e, target: t, data: s, type: o.removeEvent }),
+    Yt = (e, t, s) => ({ source: e, target: t, data: s, type: o.addEvent }),
+    Zt = (e, t, s) => ({ source: e, target: t, data: s, type: o.updateEvent }),
+    Q = (e) => ({ source: e, target: e, type: o.removeNode, data: {} }),
+    _ = (e, t) => ({ target: e, source: e, type: o.insertNode, data: t }),
+    te = (e, t, s) => ({ source: e, target: t, type: o.changeValue, data: s }),
+    ee = (e, t) => (e.type > t.type ? 1 : e.type < t.type ? -1 : 0),
+    W = { index: -1 }
+  class se {
+    constructor() {
+      this.map = {}
+    }
+    populate(t) {
+      t.forEach((s, n) => {
+        const r = s.__jsx
+        r &&
+          ((this.map[r] = this.map[r] || []),
+          this.map[r].push({ element: s, index: n }))
+      })
+    }
+    pullMatch(t) {
+      const s = t && t.__jsx
+      return !s || !(this.map[s] && this.map[s].length)
+        ? W
+        : this.map[s].shift()
+    }
+    clear(t) {
+      const s = t && t.__jsx
+      if (!(s && this.map[s] && this.map[s].length)) return
+      const n = this.map[s]
+      this.map[s] = n.reduce((r, i) => (i.element !== t && r.push(i), r), [])
+    }
+    check(t) {
+      const s = t && t.__jsx
+      return s && this.map[s] ? this.map[s].length > 0 : !1
+    }
+    remaining() {
+      return Object.values(this.map).flat()
+    }
+  }
+  const X = (e) => {
+      const t = new se()
+      return t.populate(e), t
+    },
+    Y = (e, t, s = !1) => {
+      const n = [],
+        r = e.attributes,
+        i = r.length,
+        a = t.attributes,
+        l = a.length
+      let u, d, c
+      for (u = 0; u < i; u++) {
+        c = null
+        const h = r.item(u)
+        if (h) {
+          for (d = 0; d < l; d++) {
+            const m = a.item(d)
+            if (m && h.name == m.name) {
+              c = m
+              break
+            }
+          }
+          c
+            ? h.value !== c.value &&
+              n.push(Wt(e, t, { name: h.name, value: c.value, isSvg: s }))
+            : n.push(Ht(e, t, { name: h.name, isSvg: s }))
+        }
+      }
+      for (u = 0; u < l; u++) {
+        c = null
+        const h = a.item(u)
+        if (h) {
+          for (d = 0; d < i; d++) {
+            const m = r.item(d)
+            if (m && m.name == h.name) {
+              c = m
+              break
+            }
+          }
+          c || n.push(Qt(e, t, { name: h.name, value: h.value, isSvg: s }))
+        }
+      }
+      return n
+    },
+    ne = (e, t) => {
+      const s = [],
+        n = e.eventMaps,
+        r = t.eventMaps,
+        i = Object.keys(n),
+        a = Object.keys(r)
+      return (
+        i.forEach((l) => {
+          const u = n[l],
+            d = r[l]
+          d
+            ? d.busEvent !== u.busEvent &&
+              s.push(
+                Zt(e, t, {
+                  name: l,
+                  targetValue: d.listener,
+                  sourceValue: u.listener,
+                }),
+              )
+            : s.push(Xt(e, t, { name: u.domEvent, value: u.listener }))
+        }),
+        a.forEach((l) => {
+          const u = n[l],
+            d = r[l]
+          u || s.push(Yt(e, t, { name: d.domEvent, value: d.listener }))
+        }),
+        s
+      )
+    },
+    re = (e) => e.tagName !== 'INPUT',
+    ie = (e, t) => e.value === t.value,
+    oe = (e, t) => {
+      if (re(e) || ie(e, t)) return []
+      const s = e,
+        n = t
+      return [te(s, n, { name: 'value', value: n.value })]
+    },
+    ue = (e, t) => {
+      const s = Y(e, t),
+        n = ne(e, t),
+        r = oe(e, t)
+      return s.concat(n).concat(r)
+    },
+    ae = (e, t) => Y(e, t, !0),
+    ce = (e, t) => (e.textContent !== t.textContent ? [Jt(e, t)] : []),
+    le = (e, t, s) => {
+      let n = []
+      if (e.nodeType === 1 && ct(e)) {
+        const r = e,
+          i = t,
+          a = ae(r, i),
+          l = s(r.childNodes, i.childNodes, r)
+        n = a.concat(l)
+      } else if (e.nodeType === 1) {
+        const r = e,
+          i = t,
+          a = ue(r, i),
+          l = s(r.childNodes, i.childNodes, r)
+        n = a.concat(l)
+      } else e.nodeType === 3 && (n = ce(e, t))
+      return n
+    },
+    Z = (e, t, s) => {
+      const n = [],
+        r = he(e, t),
+        i = X(e),
+        a = X(t),
+        l = []
+      let u = 0
+      for (; u < r; u++) {
+        const c = e[u],
+          h = t[u]
+        if (h && a.check(h)) {
+          const m = i.pullMatch(h)
+          a.clear(h),
+            m.element
+              ? (m.index !== u && n.push(_(m.element, { parent: s, index: u })),
+                l.push({ source: m.element, target: h }))
+              : c
+                ? a.check(c)
+                  ? n.push(_(h, { parent: s, index: u }))
+                  : (i.clear(c), n.push(Gt(c, h)))
+                : n.push(_(h, { parent: s, index: u }))
+        } else c && i.pullMatch(c).element && n.push(Q(c))
+      }
+      i.remaining().forEach(({ element: c }) => {
+        n.push(Q(c))
+      })
+      const d = l.reduce(
+        (c, { source: h, target: m }) => c.concat(le(h, m, Z)),
+        [],
+      )
+      return n.concat(d).sort(ee)
+    },
+    he = (e, t) => {
+      const s = e.length,
+        n = t.length
+      return s > n ? s : n
+    },
+    de = (e, t, s) => {
+      const n = Z(e, t, s)
+      return (
+        n.forEach((r) => {
+          pe(r)
+        }),
+        n
+      )
+    },
+    pe = (e) => {
+      ;(_e[e.type] || me)(e)
+    },
+    me = (e) => {},
+    fe = (e) => {
+      const { source: t, target: s } = e
+      t.nodeValue = s.textContent
+    },
+    be = (e) => {
+      const { source: t } = e
+      t.remove()
+    },
+    ve = (e) => {
+      const { target: t, data: s } = e,
+        { parent: n, index: r } = s,
+        i = n.childNodes[r]
+      i ? i && i !== t && n.insertBefore(t, i) : n.appendChild(t)
+    },
+    ge = (e) => {
+      const { source: t, target: s } = e
+      t.replaceWith(s)
+    },
+    ye = (e) => {
+      const { source: t, data: s } = e,
+        { name: n, isSvg: r } = s
+      r ? t.removeAttributeNS(null, n) : t.removeAttribute(n)
+    },
+    tt = (e) => {
+      const { source: t, data: s } = e,
+        { name: n, value: r, isSvg: i } = s
+      i ? t.setAttributeNS(null, n, r) : t.setAttribute(n, r)
+    },
+    Ee = (e) => {
+      tt(e)
+    },
+    Ae = (e) => {
+      const t = e.data,
+        s = e.source,
+        { name: n, value: r } = t
+      s.removeEventListener(n, r)
+    },
+    xe = (e) => {
+      const t = e.data,
+        s = e.source,
+        { name: n, value: r } = t
+      s.addEventListener(n, r)
+    },
+    we = (e) => {
+      const t = e.data,
+        s = e.source,
+        { name: n, sourceValue: r, targetValue: i } = t
+      s.removeEventListener(n, r), s.addEventListener(n, i)
+    },
+    Ne = (e) => {
+      const t = e.data,
+        s = e.source,
+        { value: n } = t
+      s.value = n
+    },
+    _e = {
+      [o.changeText]: fe,
+      [o.removeNode]: be,
+      [o.insertNode]: ve,
+      [o.replaceNode]: ge,
+      [o.removeAttribute]: ye,
+      [o.addAttribute]: tt,
+      [o.updateAttribute]: Ee,
+      [o.removeEvent]: Ae,
+      [o.addEvent]: xe,
+      [o.updateEvent]: we,
+      [o.changeValue]: Ne,
+    },
+    Se = (e, t, s) => {
+      const n = [...t]
+      return (
+        e.forEach((r) => {
+          Te(r, n, s)
+        }),
+        n
+      )
+    },
+    Te = (e, t, s) => {
+      const n = ke[e.type]
+      n && n(e, t, s)
+    },
+    je = (e, t) => {
+      const { source: s } = e,
+        n = t.indexOf(s)
+      n >= 0 && t.splice(n, 1)
+    },
+    Oe = (e, t, s) => {
+      const { target: n } = e,
+        r = e.data,
+        { index: i, parent: a } = r
+      s === a && t.splice(i, 0, n)
+    },
+    Me = (e, t) => {
+      const { target: s, source: n } = e,
+        r = t.indexOf(n)
+      r >= 0 && (t[r] = s)
+    },
+    ke = { [o.removeNode]: je, [o.insertNode]: Oe, [o.replaceNode]: Me }
+  class $e {
+    constructor({
+      Template: t,
+      subscriptions: s,
+      attributes: n,
+      viewModel: r,
+    }) {
+      ;(this.Template = t),
+        (this.viewModel = r),
+        (this.attributes = n),
+        (this.subscriptions = s),
+        (this.dom = []),
+        (this.parentElement = null)
+    }
+    render(t) {
+      return (
+        (this.parentElement = t.parent),
+        (this.renderKit = t),
+        this.subscribeForRerender(),
+        (this.dom = this.generateDom(t)),
+        this.dom
+      )
+    }
+    generateDom(t) {
+      const s = {
+          ...this.attributes,
+          ...this.viewModel(t.state.getAll(this.subscriptions)),
+        },
+        n = this.Template(s)
+      return n ? n.render(t) : []
+    }
+    rerender() {
+      if (!this.parentElement && this.dom[0]) {
+        const n = this.dom[0].parentElement
+        this.parentElement = n
+      }
+      const t = this.generateDom(this.renderKit),
+        s = de(this.dom, t, this.parentElement)
+      this.dom = Se(s, this.dom, this.parentElement)
+    }
+    subscribeForRerender() {
+      const { subscribe: t } = this.renderKit
+      this.subscriptions.forEach((s) => {
+        t(this.eventName(s), () => this.rerender())
+      })
+    }
+    eventName(t) {
+      return `${N}:${t}`
+    }
+  }
+  const De = (e) => e,
+    et = ({ Template: e, viewModel: t, subscriptions: s }) => (
+      (s = s || []),
+      (t = t || De),
+      (n) =>
+        new $e({ Template: e, viewModel: t, subscriptions: s, attributes: n })
+    ),
+    Pe = Object.freeze(
+      Object.defineProperty(
+        {
+          __proto__: null,
+          createRouteState: D,
+          events: _t,
+          extractQueryParams: F,
+          findHref: P,
+          navigate: y,
+          onLinkClick: V,
+          onLocationChange: L,
+          start: St,
+        },
+        Symbol.toStringTag,
+        { value: 'Module' },
+      ),
+    ),
+    Ve =
+      (e) =>
+      ({ path: t }) =>
+        t === e,
+    Fe = () => !0,
+    st =
+      (e) =>
+      ({ route: t }) => {
+        const s = e.find((n) => n.match(t))
+        return s && s.Partial
+      },
+    Le = Object.freeze(
+      Object.defineProperty(
+        { __proto__: null, buildRouter: st, catchAll: Fe, exactPathMatch: Ve },
+        Symbol.toStringTag,
+        { value: 'Module' },
+      ),
+    ),
+    ze = () => ({ render: (e, t) => [] }),
+    Be = (e) => {
+      const t = st(e)
+      return et({
+        Template: ({ route: n }) => (t({ route: n }) || ze)(),
+        subscriptions: ['route'],
+      })
+    }
+  ;(p.JaxsTypes = qt),
+    (p.appBuilding = Tt),
+    (p.bind = et),
+    (p.createApp = It),
+    (p.jsx = O),
+    (p.messageBus = kt),
+    (p.navigation = Pe),
+    (p.routedView = Be),
+    (p.routing = Le),
+    (p.state = Ut),
+    Object.defineProperty(p, Symbol.toStringTag, { value: 'Module' })
+})

--- a/lib/state/store.ts
+++ b/lib/state/store.ts
@@ -17,7 +17,7 @@ export class Store<T> {
   constructor(options: StoreInitializationOptions<T>) {
     this.name = options.name
     this.parent = options.parent
-    this._value = options.value
+    this._value = structuredClone(options.value)
     this.initialValue = structuredClone(options.value)
   }
 
@@ -30,7 +30,7 @@ export class Store<T> {
   }
 
   reset() {
-    this._value = this.initialValue
+    this._value = structuredClone(this.initialValue)
   }
 
   update(updater: StoreUpdaterOrValue<T>) {
@@ -50,6 +50,6 @@ export class Store<T> {
   }
 
   private getUpdatedValue(updater: StoreDataUpdater<T>) {
-    return updater(this.value)
+    return updater(structuredClone(this.value))
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jaxs",
   "description": "Modular J/TSX application framework",
   "private": false,
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "scripts": {
     "build": "vite build && npm run build:types",

--- a/test/state/store.test.ts
+++ b/test/state/store.test.ts
@@ -67,4 +67,26 @@ describe('Store', () => {
 
     expect(store.value).toEqual({ name: 'Guest', loggedIn: false })
   })
+
+  it('does not allow modification of the initial value', () => {
+    const parent = new State(vi.fn())
+    const value = {
+      name: 'Guest',
+      loggedIn: false,
+    }
+    const store = new Store({
+      name: 'currentUser',
+      parent,
+      value,
+    })
+
+    store.update((state) => {
+      state.loggedIn = true
+      state.name = 'Fred'
+      return state
+    })
+
+    expect(store.value).toEqual({ name: 'Fred', loggedIn: true })
+    expect(value).toEqual({ name: 'Guest', loggedIn: false })
+  })
 })


### PR DESCRIPTION
While the initial state was using `structuredClone` when setting the initial value, it wasn't when setting the private _value attribute. During the `update` method that took a replacement state, everything was fine, but during a update that took an updater function mutating that state, all hell brokes loose.

This fixes that bug. But I think we should also be making sure the the updater form of update gets a clone of the original data. So that was done too.